### PR TITLE
Add links to showcase demo app

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ python manage.py check_rls   # verify policies are in place
 
 **[Full tutorial and documentation →](https://dvoraj75.github.io/django-rls-tenants/)**
 
+> **Want to see it in action first?** Try the
+> [demo project](https://github.com/dvoraj75/django-rls-tenants-demo) —
+> zero to "wow" in under 5 minutes.
+
 ## Comparison with Alternatives
 
 | Feature                    | django-rls-tenants | django-tenants  | django-multitenant |

--- a/docs/index.md
+++ b/docs/index.md
@@ -99,6 +99,11 @@ MIDDLEWARE = [
 
 See the full [Quick Start tutorial](getting-started/quickstart.md) for a complete walkthrough.
 
+!!! tip "Try the demo"
+    See django-rls-tenants in action with the
+    [demo project](https://github.com/dvoraj75/django-rls-tenants-demo).
+    Clone, `docker compose up`, and explore tenant isolation in under 5 minutes.
+
 ## License
 
 [MIT](https://github.com/dvoraj75/django-rls-tenants/blob/main/LICENSE)


### PR DESCRIPTION
This pull request improves the documentation by highlighting a demo project that allows users to quickly try out the features of `django-rls-tenants`. The demo is now promoted in both the main README and the documentation index, making it easier for new users to get started.

Documentation enhancements:

* Added a prominent note in the `README.md` with a link to the demo project, encouraging users to try it out for a quick hands-on experience.
* Included a tip in `docs/index.md` with instructions and a link to the demo project, guiding users to explore tenant isolation in minutes.