### PR TITLE
Add links to showcase demo app

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ python manage.py check_rls   # verify policies are in place
 
 **[Full tutorial and documentation →](https://dvoraj75.github.io/django-rls-tenants/)**
 
+> **Want to see it in action first?** Try the
+> [demo project](https://github.com/dvoraj75/django-rls-tenants-demo) —
+> zero to "wow" in under 5 minutes.
+
 ## Comparison with Alternatives
 
 | Feature                    | django-rls-tenants | django-tenants  | django-multitenant |

--- a/docs/index.md
+++ b/docs/index.md
@@ -99,6 +99,11 @@ MIDDLEWARE = [
 
 See the full [Quick Start tutorial](getting-started/quickstart.md) for a complete walkthrough.
 
+!!! tip "Try the demo"
+    See django-rls-tenants in action with the
+    [demo project](https://github.com/dvoraj75/django-rls-tenants-demo).
+    Clone, `docker compose up`, and explore tenant isolation in under 5 minutes.
+
 ## License
 
 [MIT](https://github.com/dvoraj75/django-rls-tenants/blob/main/LICENSE)


### PR DESCRIPTION
This pull request adds prominent links to a demo project, making it easier for users to quickly try out the functionality of the package. The updates are included in both the main README and the documentation index for better visibility.

Enhancements to documentation and onboarding:

* Added a highlighted section in the `README.md` with a link to a demo project, encouraging users to try the package in under 5 minutes.
* Included a "tip" callout in `docs/index.md` with instructions and a link to the demo project, streamlining the onboarding experience for new users.