### PR TITLE
fix: use configured TENANT_FK_FIELD in _add_tenant_fk signal handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `_add_tenant_fk` signal handler now reads the configured `TENANT_FK_FIELD` value
+  instead of hardcoding `"tenant"` when checking for an existing field. Previously,
+  a custom `TENANT_FK_FIELD` (e.g., `"organization"`) would cause the handler to
+  miss existing fields and attempt to add a duplicate FK.
+
 ## [1.0.0] - 2026-03-15
 
 Initial stable release of django-rls-tenants.

--- a/django_rls_tenants/tenants/models.py
+++ b/django_rls_tenants/tenants/models.py
@@ -33,19 +33,20 @@ def _add_tenant_fk(sender: type, **kwargs: Any) -> None:  # noqa: ARG001  -- sig
         return
 
     # Skip if the subclass already defines its own tenant field
-    local_field_names = [f.name for f in sender._meta.local_fields]  # noqa: SLF001
-    if "tenant" not in local_field_names:
-        from django_rls_tenants.tenants.conf import (  # noqa: PLC0415
-            rls_tenants_config,
-        )
+    from django_rls_tenants.tenants.conf import (  # noqa: PLC0415
+        rls_tenants_config,
+    )
 
+    local_field_names = [f.name for f in sender._meta.local_fields]  # noqa: SLF001
+    field_name = rls_tenants_config.TENANT_FK_FIELD
+    if field_name not in local_field_names:
         field: models.ForeignKey[Any, Any] = models.ForeignKey(
             to=rls_tenants_config.TENANT_MODEL,
             on_delete=models.CASCADE,
             blank=False,
             null=False,
         )
-        field.contribute_to_class(sender, rls_tenants_config.TENANT_FK_FIELD)
+        field.contribute_to_class(sender, field_name)
 
 
 class_prepared.connect(_add_tenant_fk)

--- a/tests/test_tenants/test_models.py
+++ b/tests/test_tenants/test_models.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
+from django.db import models
 
 from django_rls_tenants.rls.constraints import RLSConstraint
 from django_rls_tenants.tenants.managers import RLSManager
-from django_rls_tenants.tenants.models import RLSProtectedModel
+from django_rls_tenants.tenants.models import RLSProtectedModel, _add_tenant_fk
 from tests.test_app.models import Document, Order, ProtectedUser, Tenant
 
 pytestmark = pytest.mark.django_db
@@ -78,3 +81,42 @@ class TestRLSProtectedModelMeta:
     def test_abstract_model(self):
         """RLSProtectedModel itself is abstract."""
         assert RLSProtectedModel._meta.abstract is True
+
+
+class TestAddTenantFKConfig:
+    """Tests for _add_tenant_fk respecting TENANT_FK_FIELD configuration."""
+
+    def test_respects_custom_tenant_fk_field(self):
+        """_add_tenant_fk uses the configured TENANT_FK_FIELD, not hardcoded 'tenant'.
+
+        When TENANT_FK_FIELD is set to a custom name, the signal handler should
+        check for that name when deciding whether to add the FK.
+        """
+        with patch("django_rls_tenants.tenants.conf.rls_tenants_config") as mock_config:
+            mock_config.TENANT_FK_FIELD = "organization"
+            mock_config.TENANT_MODEL = "test_app.Tenant"
+
+            # Order already has a field named "tenant" but NOT "organization".
+            # With the old hardcoded check, it would skip (because "tenant" IS in
+            # local_field_names). With the fix, it should try to add "organization".
+            # We patch contribute_to_class to verify it's called with the right name.
+            with patch.object(models.ForeignKey, "contribute_to_class") as mock_ctc:
+                _add_tenant_fk(sender=Order)
+                mock_ctc.assert_called_once()
+                _, call_field_name = mock_ctc.call_args[0]
+                assert call_field_name == "organization"
+
+    def test_no_duplicate_when_model_defines_configured_fk(self):
+        """No FK is added when the model already defines a field matching TENANT_FK_FIELD.
+
+        If a user configures TENANT_FK_FIELD='tenant' and their model already
+        has a 'tenant' field (like ProtectedUser), the signal must skip it.
+        """
+        with patch("django_rls_tenants.tenants.conf.rls_tenants_config") as mock_config:
+            mock_config.TENANT_FK_FIELD = "tenant"
+            mock_config.TENANT_MODEL = "test_app.Tenant"
+
+            with patch.object(models.ForeignKey, "contribute_to_class") as mock_ctc:
+                # ProtectedUser already defines "tenant" field
+                _add_tenant_fk(sender=ProtectedUser)
+                mock_ctc.assert_not_called()


### PR DESCRIPTION
This pull request fixes a bug in the `_add_tenant_fk` signal handler so that it now respects the configured `TENANT_FK_FIELD` value instead of always using the hardcoded `"tenant"` field name. This ensures that projects customizing the tenant foreign key field name (e.g., to `"organization"`) will not encounter duplicate foreign key errors. Additionally, new tests are added to verify this behavior.

**Bug fix:**

* The `_add_tenant_fk` signal handler now checks for the configured `TENANT_FK_FIELD` when determining whether to add a foreign key, preventing duplicate FK fields if a custom name is used. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R16) [[2]](diffhunk://#diff-77c49c50d12b85ab423276db61006db39c6aca0ec071d54a5e9fe699aff60666L36-R49)

**Testing improvements:**

* Added tests in `tests/test_tenants/test_models.py` to verify that `_add_tenant_fk` respects the `TENANT_FK_FIELD` configuration and does not add duplicate foreign keys when the field already exists. [[1]](diffhunk://#diff-fcc1fa90e2e52152a753de40e19c35a796ec043114eab88ea86d56ef214c15c3R5-R12) [[2]](diffhunk://#diff-fcc1fa90e2e52152a753de40e19c35a796ec043114eab88ea86d56ef214c15c3R84-R127)