### PR TITLE
Add custom exception hierarchy for precise error handling (#12)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,8 +144,17 @@ def set_guc(name: str, value: str, *, is_local: bool = False) -> None:
 
 ### Error Handling
 
-- Use **stdlib exceptions** — `ValueError` for bad arguments, `RuntimeError` for
-  incorrect usage context. No custom exception classes.
+- **Custom exceptions** live in `django_rls_tenants/exceptions.py` (package root,
+  usable by both `rls/` and `tenants/` layers):
+  - `RLSTenantError(Exception)` — base for all library errors.
+  - `NoTenantContextError(RLSTenantError)` — missing tenant context (e.g.,
+    `tenant_context(None)`, non-admin with `rls_tenant_id=None`).
+  - `RLSConfigurationError(RLSTenantError)` — invalid/missing config (e.g.,
+    missing `TENANT_MODEL`).
+- The **`rls/` layer** still uses stdlib exceptions (`ValueError` for input
+  validation / SQL injection guards, `RuntimeError` for misuse like SET LOCAL
+  outside a transaction). This keeps the generic layer free of tenant-specific
+  concerns.
 - Error messages must be **descriptive f-strings** explaining both the problem and
   how to fix it (`TRY003` is intentionally ignored).
 - **Logging:** `logger = logging.getLogger("django_rls_tenants")`. Use `%s` format

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Custom exception hierarchy in `django_rls_tenants.exceptions`: `RLSTenantError`
+  (base), `NoTenantContextError`, `RLSConfigurationError`. All importable from
+  the top-level `django_rls_tenants` package. (#12)
+
+### Changed
+
+- `tenant_context()` and `_resolve_user_guc_vars()` now raise
+  `NoTenantContextError` instead of `ValueError` when a non-admin user has
+  `rls_tenant_id=None` or when `tenant_id` is `None`.
+- `@with_rls_context` decorator now raises `NoTenantContextError` instead of
+  `ValueError` when a non-admin user has `rls_tenant_id=None`.
+- `RLSTenantsConfig._get()` now raises `RLSConfigurationError` instead of
+  `ValueError` when a required config key (e.g., `TENANT_MODEL`) is missing.
+
 ## [1.1.0] - 2026-03-17
 
 ### Added

--- a/django_rls_tenants/__init__.py
+++ b/django_rls_tenants/__init__.py
@@ -12,9 +12,12 @@ if TYPE_CHECKING:
 __version__: str = importlib.metadata.version("django-rls-tenants")
 
 __all__ = [
+    "NoTenantContextError",
+    "RLSConfigurationError",
     "RLSConstraint",
     "RLSManager",
     "RLSProtectedModel",
+    "RLSTenantError",
     "RLSTenantMiddleware",
     "TenantQuerySet",
     "TenantUser",
@@ -28,9 +31,12 @@ __all__ = [
 ]
 
 _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
+    "NoTenantContextError": ("django_rls_tenants.exceptions", "NoTenantContextError"),
+    "RLSConfigurationError": ("django_rls_tenants.exceptions", "RLSConfigurationError"),
     "RLSConstraint": ("django_rls_tenants.rls.constraints", "RLSConstraint"),
     "RLSManager": ("django_rls_tenants.tenants.managers", "RLSManager"),
     "RLSProtectedModel": ("django_rls_tenants.tenants.models", "RLSProtectedModel"),
+    "RLSTenantError": ("django_rls_tenants.exceptions", "RLSTenantError"),
     "RLSTenantMiddleware": ("django_rls_tenants.tenants.middleware", "RLSTenantMiddleware"),
     "TenantQuerySet": ("django_rls_tenants.tenants.managers", "TenantQuerySet"),
     "TenantUser": ("django_rls_tenants.tenants.types", "TenantUser"),

--- a/django_rls_tenants/apps.py
+++ b/django_rls_tenants/apps.py
@@ -64,5 +64,7 @@ class DjangoRlsTenantsConfig(AppConfig):
         import django_rls_tenants.tenants.checks  # noqa: PLC0415, F401
 
         # Validate configuration at startup
-        with contextlib.suppress(ValueError):
+        from django_rls_tenants.exceptions import RLSConfigurationError  # noqa: PLC0415
+
+        with contextlib.suppress(RLSConfigurationError):
             _ = rls_tenants_config.TENANT_MODEL

--- a/django_rls_tenants/exceptions.py
+++ b/django_rls_tenants/exceptions.py
@@ -1,0 +1,35 @@
+"""Custom exceptions for django-rls-tenants.
+
+All library-specific exceptions inherit from ``RLSTenantError``,
+giving callers a single base type to catch any error raised by the
+library while still allowing precise handling of specific conditions.
+"""
+
+from __future__ import annotations
+
+
+class RLSTenantError(Exception):
+    """Base exception for all django-rls-tenants errors.
+
+    Catch this to handle any error raised by the library.
+    """
+
+
+class NoTenantContextError(RLSTenantError):
+    """Query or context operation attempted without an active tenant context.
+
+    Raised when ``STRICT_MODE=True`` and a queryset evaluation is attempted
+    without an active ``tenant_context()``, ``admin_context()``,
+    ``for_user()``, or ``RLSTenantMiddleware`` context.
+
+    Also raised by ``tenant_context()`` and ``_resolve_user_guc_vars()``
+    when a non-admin user has ``rls_tenant_id=None``.
+    """
+
+
+class RLSConfigurationError(RLSTenantError):
+    """Invalid or missing RLS configuration.
+
+    Raised when a required configuration key is missing from
+    ``settings.RLS_TENANTS`` or when a configuration value is invalid.
+    """

--- a/django_rls_tenants/tenants/__init__.py
+++ b/django_rls_tenants/tenants/__init__.py
@@ -6,6 +6,11 @@ and testing utilities.
 
 from __future__ import annotations
 
+from django_rls_tenants.exceptions import (
+    NoTenantContextError,
+    RLSConfigurationError,
+    RLSTenantError,
+)
 from django_rls_tenants.tenants.bypass import (
     bypass_flag,
     clear_bypass_flag,
@@ -27,8 +32,11 @@ from django_rls_tenants.tenants.state import (
 from django_rls_tenants.tenants.types import TenantUser
 
 __all__ = [
+    "NoTenantContextError",
+    "RLSConfigurationError",
     "RLSManager",
     "RLSProtectedModel",
+    "RLSTenantError",
     "TenantQuerySet",
     "TenantUser",
     "admin_context",

--- a/django_rls_tenants/tenants/conf.py
+++ b/django_rls_tenants/tenants/conf.py
@@ -11,6 +11,8 @@ from typing import Any
 
 from django.conf import settings
 
+from django_rls_tenants.exceptions import RLSConfigurationError
+
 # All recognized keys in the RLS_TENANTS configuration dict.
 _KNOWN_KEYS = frozenset(
     {
@@ -91,7 +93,7 @@ class RLSTenantsConfig:
         On first access, warns about any unrecognized keys (likely typos).
 
         Raises:
-            ValueError: If ``key`` is required (no default) and missing.
+            RLSConfigurationError: If ``key`` is required (no default) and missing.
         """
         cached = self._config_cache
         if cached is None:
@@ -105,7 +107,7 @@ class RLSTenantsConfig:
                 f"Add it to your Django settings: "
                 f"RLS_TENANTS = {{'{key}': ...}}"
             )
-            raise ValueError(msg)
+            raise RLSConfigurationError(msg)
         return value
 
     def _warn_unknown_keys(self, config: dict[str, Any]) -> None:

--- a/django_rls_tenants/tenants/context.py
+++ b/django_rls_tenants/tenants/context.py
@@ -13,6 +13,7 @@ import logging
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any
 
+from django_rls_tenants.exceptions import NoTenantContextError
 from django_rls_tenants.rls.guc import clear_guc, get_guc, set_guc
 from django_rls_tenants.tenants.conf import rls_tenants_config
 from django_rls_tenants.tenants.state import reset_current_tenant_id, set_current_tenant_id
@@ -60,7 +61,7 @@ def _resolve_user_guc_vars(
             f"Assign the user to a tenant or set is_tenant_admin=True. "
             f"User type: {type(user).__name__}"
         )
-        raise ValueError(msg)
+        raise NoTenantContextError(msg)
     return {
         conf.GUC_IS_ADMIN: "false",
         conf.GUC_CURRENT_TENANT: str(tenant_id),
@@ -80,11 +81,11 @@ def tenant_context(
         using: Database alias. Default: ``"default"``.
 
     Raises:
-        ValueError: If ``tenant_id`` is ``None``.
+        NoTenantContextError: If ``tenant_id`` is ``None``.
     """
     if tenant_id is None:
         msg = "tenant_id cannot be None. For admin access, use admin_context() instead."
-        raise ValueError(msg)
+        raise NoTenantContextError(msg)
 
     conf = rls_tenants_config
     is_local = conf.USE_LOCAL_SET
@@ -235,7 +236,7 @@ def with_rls_context(
                         f"rls_tenant_id=None. Assign the user to a tenant "
                         f"or set is_tenant_admin=True."
                     )
-                    raise ValueError(msg)
+                    raise NoTenantContextError(msg)
                 ctx = tenant_context(tenant_id)
             else:
                 logger.warning(

--- a/docs/guides/context-managers.md
+++ b/docs/guides/context-managers.md
@@ -30,11 +30,13 @@ with tenant_context(tenant_id=42):
 - Sets the internal `ContextVar` state so `RLSManager.get_queryset()` automatically
   adds `WHERE tenant_id = X` to all queries (auto-scoping).
 - Saves and restores previous GUC values and state on exit (supports nesting).
-- Raises `ValueError` if `tenant_id` is `None`.
+- Raises `NoTenantContextError` if `tenant_id` is `None`.
 
 ```python
-# ValueError: use admin_context() for admin access
-with tenant_context(tenant_id=None):  # raises ValueError
+from django_rls_tenants import NoTenantContextError
+
+# NoTenantContextError: use admin_context() for admin access
+with tenant_context(tenant_id=None):  # raises NoTenantContextError
     ...
 ```
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -8,9 +8,12 @@ The most common symbols are available directly from `django_rls_tenants`:
 
 ```python
 from django_rls_tenants import (
+    NoTenantContextError,
+    RLSConfigurationError,
     RLSConstraint,
     RLSManager,
     RLSProtectedModel,
+    RLSTenantError,
     RLSTenantMiddleware,
     TenantQuerySet,
     TenantUser,
@@ -22,6 +25,19 @@ from django_rls_tenants import (
     with_rls_context,
 )
 ```
+
+---
+
+## Exceptions
+
+Custom exception hierarchy for precise error handling. All exceptions live in
+`django_rls_tenants.exceptions` and are re-exported from the top-level package.
+
+::: django_rls_tenants.exceptions.RLSTenantError
+
+::: django_rls_tenants.exceptions.NoTenantContextError
+
+::: django_rls_tenants.exceptions.RLSConfigurationError
 
 ---
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,65 @@
+"""Tests for django_rls_tenants.exceptions."""
+
+from __future__ import annotations
+
+from django_rls_tenants.exceptions import (
+    NoTenantContextError,
+    RLSConfigurationError,
+    RLSTenantError,
+)
+
+
+class TestExceptionHierarchy:
+    """Verify the exception class hierarchy."""
+
+    def test_rls_tenant_error_is_exception(self):
+        """RLSTenantError inherits from Exception."""
+        assert issubclass(RLSTenantError, Exception)
+
+    def test_no_tenant_context_error_is_rls_tenant_error(self):
+        """NoTenantContextError inherits from RLSTenantError."""
+        assert issubclass(NoTenantContextError, RLSTenantError)
+
+    def test_rls_configuration_error_is_rls_tenant_error(self):
+        """RLSConfigurationError inherits from RLSTenantError."""
+        assert issubclass(RLSConfigurationError, RLSTenantError)
+
+    def test_no_tenant_context_error_is_not_value_error(self):
+        """NoTenantContextError does not inherit from ValueError."""
+        assert not issubclass(NoTenantContextError, ValueError)
+
+    def test_rls_configuration_error_is_not_value_error(self):
+        """RLSConfigurationError does not inherit from ValueError."""
+        assert not issubclass(RLSConfigurationError, ValueError)
+
+    def test_rls_tenant_error_is_not_runtime_error(self):
+        """RLSTenantError does not inherit from RuntimeError."""
+        assert not issubclass(RLSTenantError, RuntimeError)
+
+    def test_catch_base_catches_no_tenant_context(self):
+        """Catching RLSTenantError also catches NoTenantContextError."""
+        with_caught = False
+        try:
+            raise NoTenantContextError("test")
+        except RLSTenantError:
+            with_caught = True
+        assert with_caught
+
+    def test_catch_base_catches_configuration_error(self):
+        """Catching RLSTenantError also catches RLSConfigurationError."""
+        with_caught = False
+        try:
+            raise RLSConfigurationError("test")
+        except RLSTenantError:
+            with_caught = True
+        assert with_caught
+
+    def test_no_tenant_context_error_message(self):
+        """NoTenantContextError preserves the error message."""
+        err = NoTenantContextError("missing context")
+        assert str(err) == "missing context"
+
+    def test_rls_configuration_error_message(self):
+        """RLSConfigurationError preserves the error message."""
+        err = RLSConfigurationError("bad config")
+        assert str(err) == "bad config"

--- a/tests/test_layering.py
+++ b/tests/test_layering.py
@@ -62,6 +62,27 @@ class TestLazyImports:
         assert admin_context is ctx_mod.admin_context
         assert tenant_context is ctx_mod.tenant_context
 
+    def test_exceptions(self):
+        """Exception classes are importable from the top-level package."""
+        from django_rls_tenants import (  # noqa: PLC0415
+            NoTenantContextError,
+            RLSConfigurationError,
+            RLSTenantError,
+        )
+        from django_rls_tenants.exceptions import (  # noqa: PLC0415
+            NoTenantContextError as DirectNoCtx,
+        )
+        from django_rls_tenants.exceptions import (  # noqa: PLC0415
+            RLSConfigurationError as DirectCfgErr,
+        )
+        from django_rls_tenants.exceptions import (  # noqa: PLC0415
+            RLSTenantError as DirectBase,
+        )
+
+        assert NoTenantContextError is DirectNoCtx
+        assert RLSConfigurationError is DirectCfgErr
+        assert RLSTenantError is DirectBase
+
     def test_invalid_attribute_raises(self):
         """Accessing an undefined attribute raises AttributeError."""
         import django_rls_tenants  # noqa: PLC0415

--- a/tests/test_tenants/test_conf.py
+++ b/tests/test_tenants/test_conf.py
@@ -7,6 +7,7 @@ import warnings as w
 import pytest
 from django.test import override_settings
 
+from django_rls_tenants.exceptions import RLSConfigurationError
 from django_rls_tenants.tenants.conf import RLSTenantsConfig
 
 
@@ -19,21 +20,21 @@ class TestRLSTenantsConfig:
         assert conf.TENANT_MODEL == "test_app.Tenant"
 
     def test_missing_tenant_model_raises(self):
-        """Missing TENANT_MODEL raises ValueError with helpful message."""
+        """Missing TENANT_MODEL raises RLSConfigurationError with helpful message."""
         with override_settings(RLS_TENANTS={}):
             conf = RLSTenantsConfig()
-            with pytest.raises(ValueError, match="TENANT_MODEL"):
+            with pytest.raises(RLSConfigurationError, match="TENANT_MODEL"):
                 _ = conf.TENANT_MODEL
 
     def test_missing_rls_tenants_setting_raises(self):
-        """No RLS_TENANTS setting at all raises ValueError."""
+        """No RLS_TENANTS setting at all raises RLSConfigurationError."""
         with override_settings():
             from django.conf import settings  # noqa: PLC0415  -- must be inside override_settings
 
             if hasattr(settings, "RLS_TENANTS"):
                 delattr(settings, "RLS_TENANTS")
             conf = RLSTenantsConfig()
-            with pytest.raises(ValueError, match="TENANT_MODEL"):
+            with pytest.raises(RLSConfigurationError, match="TENANT_MODEL"):
                 _ = conf.TENANT_MODEL
 
     def test_guc_prefix_default(self):

--- a/tests/test_tenants/test_context.py
+++ b/tests/test_tenants/test_context.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from django_rls_tenants.exceptions import NoTenantContextError
 from django_rls_tenants.rls.guc import get_guc, set_guc
 from django_rls_tenants.tenants.context import (
     _resolve_user_guc_vars,
@@ -45,9 +46,9 @@ class TestTenantContext:
         assert get_guc("rls.is_admin") == "true"
         assert get_guc("rls.current_tenant") == "999"
 
-    def test_none_raises_valueerror(self):
-        """tenant_context(None) raises ValueError."""
-        with pytest.raises(ValueError, match="tenant_id cannot be None"):  # noqa: SIM117
+    def test_none_raises_no_tenant_context_error(self):
+        """tenant_context(None) raises NoTenantContextError."""
+        with pytest.raises(NoTenantContextError, match="tenant_id cannot be None"):  # noqa: SIM117
             with tenant_context(None):
                 pass
 
@@ -195,11 +196,11 @@ class TestResolveUserGucVars:
         assert result["rls.current_tenant"] == str(tenant_a_user.rls_tenant_id)
 
     def test_non_admin_with_none_tenant_id_raises(self):
-        """Non-admin user with rls_tenant_id=None raises ValueError."""
+        """Non-admin user with rls_tenant_id=None raises NoTenantContextError."""
         user = MagicMock()
         user.is_tenant_admin = False
         user.rls_tenant_id = None
-        with pytest.raises(ValueError, match="rls_tenant_id=None"):
+        with pytest.raises(NoTenantContextError, match="rls_tenant_id=None"):
             _resolve_user_guc_vars(user)
 
     def test_admin_with_none_tenant_id_ok(self):
@@ -289,7 +290,7 @@ class TestWithRlsContext:
         assert get_guc("rls.is_admin") is None
 
     def test_non_admin_with_none_tenant_id_raises(self):
-        """Decorator raises ValueError for non-admin user with rls_tenant_id=None."""
+        """Decorator raises NoTenantContextError for non-admin user with rls_tenant_id=None."""
         user = MagicMock()
         user.is_tenant_admin = False
         user.rls_tenant_id = None
@@ -298,7 +299,7 @@ class TestWithRlsContext:
         def my_func(as_user):
             return "should not reach"
 
-        with pytest.raises(ValueError, match="rls_tenant_id=None"):
+        with pytest.raises(NoTenantContextError, match="rls_tenant_id=None"):
             my_func(as_user=user)
 
 


### PR DESCRIPTION
This pull request introduces a new custom exception hierarchy for the `django-rls-tenants` library, replacing previous uses of `ValueError` for tenant/context and configuration errors. The new exceptions are implemented in a dedicated module, re-exported at the top level, and integrated throughout the codebase and documentation. Comprehensive tests verify the new exception classes and their usage.

**Exception Hierarchy and Usage Changes:**

* Added a new custom exception hierarchy in `django_rls_tenants.exceptions`:
  - `RLSTenantError` (base class)
  - `NoTenantContextError` (for missing tenant context)
  - `RLSConfigurationError` (for invalid/missing configuration)
  All are importable from the top-level package. [[1]](diffhunk://#diff-e0d4c4392f321f4295869f06504b1e897d5b3ff898044f1de6b9833597664135R1-R35) [[2]](diffhunk://#diff-9fd659aa53e079b3712dbf5d2c2ac6145723cd110adb9df198d6e65441f9dd1cR15-R20) [[3]](diffhunk://#diff-9fd659aa53e079b3712dbf5d2c2ac6145723cd110adb9df198d6e65441f9dd1cR34-R39) [[4]](diffhunk://#diff-cedf9ff0a20ca7f6426cdfc2351c9979d559b67ba0a9358c407df40ab55b0e8dR9-R13) [[5]](diffhunk://#diff-cedf9ff0a20ca7f6426cdfc2351c9979d559b67ba0a9358c407df40ab55b0e8dR35-R39) [[6]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R25) [[7]](diffhunk://#diff-370381df31c8d799afe0208a3b1f1c161b3f48ad3c5b5813e481c42f46161797R11-R16) [[8]](diffhunk://#diff-370381df31c8d799afe0208a3b1f1c161b3f48ad3c5b5813e481c42f46161797R31-R43)

* Updated the codebase to use the new exceptions instead of `ValueError`:
  - `tenant_context()`, `_resolve_user_guc_vars()`, and `@with_rls_context` now raise `NoTenantContextError` for missing tenant context.
  - `RLSTenantsConfig._get()` now raises `RLSConfigurationError` for missing configuration.
  - Adjusted error handling and context manager documentation accordingly. [[1]](diffhunk://#diff-ef7641bce825447cf725747e5d04c0ec13eb2859a207aacf6350bedf5252b154L63-R64) [[2]](diffhunk://#diff-ef7641bce825447cf725747e5d04c0ec13eb2859a207aacf6350bedf5252b154L83-R88) [[3]](diffhunk://#diff-ef7641bce825447cf725747e5d04c0ec13eb2859a207aacf6350bedf5252b154L238-R239) [[4]](diffhunk://#diff-5eebef5003930a17826e073530791b81efaa6c658cc09fbeb126152f95da3c25R14-R15) [[5]](diffhunk://#diff-5eebef5003930a17826e073530791b81efaa6c658cc09fbeb126152f95da3c25L94-R96) [[6]](diffhunk://#diff-5eebef5003930a17826e073530791b81efaa6c658cc09fbeb126152f95da3c25L108-R110) [[7]](diffhunk://#diff-f30ecd03fff354c9d8798efc07b69cf630944e54e71a4df6df7ebec9113fbf8bL67-R69) [[8]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L147-R157) [[9]](diffhunk://#diff-f8b3c827831ff021794c88eabe90e62f8ff27bdefdd92dad0e5865df0abf266bL33-R39)

**Documentation Updates:**

* Updated API and context manager documentation to reference the new exception classes and explain their usage. [[1]](diffhunk://#diff-f8b3c827831ff021794c88eabe90e62f8ff27bdefdd92dad0e5865df0abf266bL33-R39) [[2]](diffhunk://#diff-370381df31c8d799afe0208a3b1f1c161b3f48ad3c5b5813e481c42f46161797R11-R16) [[3]](diffhunk://#diff-370381df31c8d799afe0208a3b1f1c161b3f48ad3c5b5813e481c42f46161797R31-R43) [[4]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L147-R157)

**Testing Improvements:**

* Added new tests for the exception hierarchy and their importability.
* Updated existing tests to expect the new exception types instead of `ValueError`. [[1]](diffhunk://#diff-f46006e3f43ffb1dd5d6862005427f6620f4dcfb1fa2f883d8482550069eeeccR1-R65) [[2]](diffhunk://#diff-5a08c7ed79e0c2d19aff7b9fdd6d725294583d4cdad8142da3be3e9c26ace171R65-R85) [[3]](diffhunk://#diff-c8660f7e20d3f4641954e708506fbafb20a0a5ca077a59c76d0efafcb511a5efR10) [[4]](diffhunk://#diff-c8660f7e20d3f4641954e708506fbafb20a0a5ca077a59c76d0efafcb511a5efL22-R37) [[5]](diffhunk://#diff-6844dfd9d1046c30cbee5dedc6475bc465110611d948d7f6a99a701309448a89R10) [[6]](diffhunk://#diff-6844dfd9d1046c30cbee5dedc6475bc465110611d948d7f6a99a701309448a89L48-R51) [[7]](diffhunk://#diff-6844dfd9d1046c30cbee5dedc6475bc465110611d948d7f6a99a701309448a89L198-R203) [[8]](diffhunk://#diff-6844dfd9d1046c30cbee5dedc6475bc465110611d948d7f6a99a701309448a89L292-R293)