### PR TITLE
Add strict mode for ORM-level tenant context enforcement (#13)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,17 @@ The safety-net `request_finished` handler clears GUCs on all configured aliases.
 When modifying middleware or GUC-related code, ensure all database iteration
 uses `conf.DATABASES` rather than hardcoding `"default"`.
 
+### Strict Mode
+
+When `STRICT_MODE=True`, `TenantQuerySet` evaluation methods raise
+`NoTenantContextError` if no RLS context is active. A second `ContextVar`
+(`_rls_context_active` in `state.py`) tracks whether `tenant_context()`,
+`admin_context()`, `RLSTenantMiddleware`, or `for_user()` has established
+context. This distinguishes "no context" (should raise) from "admin context"
+(both have `_current_tenant_id=None`). All entry points set the flag to `True`
+on entry and restore via token on exit. The guard is in
+`TenantQuerySet._check_strict_mode()`.
+
 ## Code Style
 
 ### General Formatting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `STRICT_MODE` configuration option. When enabled, `TenantQuerySet` evaluation
+  methods (`count()`, `exists()`, `aggregate()`, `update()`, `delete()`,
+  `iterator()`, `bulk_create()`, `bulk_update()`, `get()`, `first()`, `last()`,
+  and iteration via `_fetch_all()`) raise `NoTenantContextError` if no RLS
+  context is active. Off by default. (#13)
+- `_rls_context_active` ContextVar in `state.py` with public accessors
+  `get_rls_context_active()`, `set_rls_context_active()`, and
+  `reset_rls_context_active()`. Tracks whether any RLS context (tenant or admin)
+  is active, enabling strict mode to distinguish "no context" from "admin
+  context". (#13)
 - Custom exception hierarchy in `django_rls_tenants.exceptions`: `RLSTenantError`
   (base), `NoTenantContextError`, `RLSConfigurationError`. All importable from
   the top-level `django_rls_tenants` package. (#12)
@@ -23,6 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `tenant_context()`, `admin_context()`, `RLSTenantMiddleware`, and `for_user()`
+  now set `_rls_context_active=True` on entry and restore the previous value on
+  exit. This enables strict mode's "no context" detection. (#13)
 - `tenant_context()` and `_resolve_user_guc_vars()` now raise
   `NoTenantContextError` instead of `ValueError` when a non-admin user has
   `rls_tenant_id=None` or when `tenant_id` is `None`.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ RLS_TENANTS = {
     "USER_PARAM_NAME": "as_user",
     "TENANT_PK_TYPE": "int",
     "USE_LOCAL_SET": False,
+    "DATABASES": ["default"],
+    "STRICT_MODE": False,
 }
 
 MIDDLEWARE = [..."django_rls_tenants.RLSTenantMiddleware"]

--- a/django_rls_tenants/__init__.py
+++ b/django_rls_tenants/__init__.py
@@ -24,8 +24,11 @@ __all__ = [
     "__version__",
     "admin_context",
     "get_current_tenant_id",
+    "get_rls_context_active",
     "reset_current_tenant_id",
+    "reset_rls_context_active",
     "set_current_tenant_id",
+    "set_rls_context_active",
     "tenant_context",
     "with_rls_context",
 ]
@@ -42,8 +45,11 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "TenantUser": ("django_rls_tenants.tenants.types", "TenantUser"),
     "admin_context": ("django_rls_tenants.tenants.context", "admin_context"),
     "get_current_tenant_id": ("django_rls_tenants.tenants.state", "get_current_tenant_id"),
+    "get_rls_context_active": ("django_rls_tenants.tenants.state", "get_rls_context_active"),
     "reset_current_tenant_id": ("django_rls_tenants.tenants.state", "reset_current_tenant_id"),
+    "reset_rls_context_active": ("django_rls_tenants.tenants.state", "reset_rls_context_active"),
     "set_current_tenant_id": ("django_rls_tenants.tenants.state", "set_current_tenant_id"),
+    "set_rls_context_active": ("django_rls_tenants.tenants.state", "set_rls_context_active"),
     "tenant_context": ("django_rls_tenants.tenants.context", "tenant_context"),
     "with_rls_context": ("django_rls_tenants.tenants.context", "with_rls_context"),
 }

--- a/django_rls_tenants/tenants/__init__.py
+++ b/django_rls_tenants/tenants/__init__.py
@@ -26,8 +26,11 @@ from django_rls_tenants.tenants.managers import RLSManager, TenantQuerySet
 from django_rls_tenants.tenants.models import RLSProtectedModel
 from django_rls_tenants.tenants.state import (
     get_current_tenant_id,
+    get_rls_context_active,
     reset_current_tenant_id,
+    reset_rls_context_active,
     set_current_tenant_id,
+    set_rls_context_active,
 )
 from django_rls_tenants.tenants.types import TenantUser
 
@@ -43,10 +46,13 @@ __all__ = [
     "bypass_flag",
     "clear_bypass_flag",
     "get_current_tenant_id",
+    "get_rls_context_active",
     "reset_current_tenant_id",
+    "reset_rls_context_active",
     "rls_tenants_config",
     "set_bypass_flag",
     "set_current_tenant_id",
+    "set_rls_context_active",
     "tenant_context",
     "with_rls_context",
 ]

--- a/django_rls_tenants/tenants/conf.py
+++ b/django_rls_tenants/tenants/conf.py
@@ -18,6 +18,7 @@ _KNOWN_KEYS = frozenset(
     {
         "DATABASES",
         "GUC_PREFIX",
+        "STRICT_MODE",
         "TENANT_FK_FIELD",
         "TENANT_MODEL",
         "TENANT_PK_TYPE",
@@ -36,6 +37,7 @@ class RLSTenantsConfig:
             "TENANT_MODEL": "myapp.Tenant",       # Required
             "DATABASES": ["default"],              # Default: ["default"]
             "GUC_PREFIX": "rls",                   # Default: "rls"
+            "STRICT_MODE": False,                  # Default: False
             "TENANT_FK_FIELD": "tenant",           # Default: "tenant"
             "USER_PARAM_NAME": "as_user",          # Default: "as_user"
             "TENANT_PK_TYPE": "int",               # Default: "int"
@@ -82,6 +84,17 @@ class RLSTenantsConfig:
     def USE_LOCAL_SET(self) -> bool:
         """Use ``SET LOCAL`` instead of ``set_config``. Default: ``False``."""
         return self._get("USE_LOCAL_SET", default=False)  # type: ignore[no-any-return]
+
+    @property
+    def STRICT_MODE(self) -> bool:
+        """Raise on queries without tenant context. Default: ``False``.
+
+        When enabled, ``TenantQuerySet`` evaluation methods raise
+        ``NoTenantContextError`` if no RLS context is active (no
+        ``tenant_context()``, ``admin_context()``, ``for_user()``,
+        or ``RLSTenantMiddleware``).
+        """
+        return self._get("STRICT_MODE", default=False)  # type: ignore[no-any-return]
 
     @property
     def DATABASES(self) -> list[str]:

--- a/django_rls_tenants/tenants/context.py
+++ b/django_rls_tenants/tenants/context.py
@@ -16,7 +16,12 @@ from typing import TYPE_CHECKING, Any
 from django_rls_tenants.exceptions import NoTenantContextError
 from django_rls_tenants.rls.guc import clear_guc, get_guc, set_guc
 from django_rls_tenants.tenants.conf import rls_tenants_config
-from django_rls_tenants.tenants.state import reset_current_tenant_id, set_current_tenant_id
+from django_rls_tenants.tenants.state import (
+    reset_current_tenant_id,
+    reset_rls_context_active,
+    set_current_tenant_id,
+    set_rls_context_active,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
@@ -97,6 +102,7 @@ def tenant_context(
         prev_admin = get_guc(conf.GUC_IS_ADMIN, using=using)
         prev_tenant = get_guc(conf.GUC_CURRENT_TENANT, using=using)
 
+    active_token = set_rls_context_active(True)
     token = set_current_tenant_id(tenant_id)
     try:
         set_guc(conf.GUC_IS_ADMIN, "false", is_local=is_local, using=using)
@@ -109,6 +115,7 @@ def tenant_context(
         yield
     finally:
         reset_current_tenant_id(token)
+        reset_rls_context_active(active_token)
         if not is_local:
             _restore_guc(conf.GUC_IS_ADMIN, prev_admin, using=using)
             _restore_guc(conf.GUC_CURRENT_TENANT, prev_tenant, using=using)
@@ -134,6 +141,7 @@ def admin_context(
         prev_admin = get_guc(conf.GUC_IS_ADMIN, using=using)
         prev_tenant = get_guc(conf.GUC_CURRENT_TENANT, using=using)
 
+    active_token = set_rls_context_active(True)
     token = set_current_tenant_id(None)
     try:
         set_guc(conf.GUC_IS_ADMIN, "true", is_local=is_local, using=using)
@@ -144,6 +152,7 @@ def admin_context(
         yield
     finally:
         reset_current_tenant_id(token)
+        reset_rls_context_active(active_token)
         if not is_local:
             _restore_guc(conf.GUC_IS_ADMIN, prev_admin, using=using)
             _restore_guc(conf.GUC_CURRENT_TENANT, prev_tenant, using=using)

--- a/django_rls_tenants/tenants/managers.py
+++ b/django_rls_tenants/tenants/managers.py
@@ -32,11 +32,13 @@ from django.core.exceptions import FieldDoesNotExist
 from django.db import models
 from django.db.models import Q
 
+from django_rls_tenants.exceptions import NoTenantContextError
 from django_rls_tenants.rls.guc import clear_guc, set_guc
 from django_rls_tenants.tenants.conf import rls_tenants_config
 from django_rls_tenants.tenants.context import _resolve_user_guc_vars
 from django_rls_tenants.tenants.state import (
     get_current_tenant_id,
+    get_rls_context_active,
     reset_current_tenant_id,
     set_current_tenant_id,
 )
@@ -225,6 +227,124 @@ class TenantQuerySet(models.QuerySet):  # type: ignore[type-arg]
         clone._rls_user = self._rls_user
         return clone
 
+    # ---- Strict mode guard ----
+
+    def _check_strict_mode(self) -> None:
+        """Raise if strict mode is on and no RLS context is active.
+
+        Only applies to RLS-protected models (those with an
+        ``RLSConstraint``). Non-protected models that happen to use
+        ``TenantQuerySet`` (e.g., via inheritance) are not guarded.
+
+        The check reads two ``ContextVar`` values -- negligible cost.
+
+        Raises:
+            NoTenantContextError: If ``STRICT_MODE=True`` and neither a
+                context manager/middleware nor ``for_user()`` has
+                established an RLS context.
+        """
+        if not rls_tenants_config.STRICT_MODE:
+            return
+        if not _is_rls_protected(self.model):
+            return  # not an RLS-protected model; skip guard
+        if get_rls_context_active():
+            return  # tenant_context / admin_context / middleware active
+        if self._rls_user is not None:
+            return  # for_user() was called
+        model_name = self.model.__name__
+        msg = (
+            f"RLS strict mode: query on {model_name} attempted without "
+            f"tenant context. Use tenant_context(), admin_context(), "
+            f"for_user(), or RLSTenantMiddleware before querying "
+            f"RLS-protected models. Set STRICT_MODE=False in RLS_TENANTS "
+            f"to disable this check."
+        )
+        raise NoTenantContextError(msg)
+
+    # ---- Guarded evaluation methods ----
+    #
+    # Methods like first()/last()/get() may also trigger _fetch_all()
+    # on a cloned queryset internally, resulting in a double check.
+    # This is intentional defense-in-depth: the direct check here
+    # catches the call at the public API boundary, while the
+    # _fetch_all() check catches any code path that reaches
+    # evaluation without going through these overrides.
+
+    def count(self) -> int:
+        """Guard ``count()`` with strict mode check."""
+        self._check_strict_mode()
+        return super().count()
+
+    def exists(self) -> bool:
+        """Guard ``exists()`` with strict mode check."""
+        self._check_strict_mode()
+        return super().exists()
+
+    def aggregate(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        """Guard ``aggregate()`` with strict mode check."""
+        self._check_strict_mode()
+        return super().aggregate(*args, **kwargs)
+
+    def update(self, **kwargs: Any) -> int:
+        """Guard ``update()`` with strict mode check."""
+        self._check_strict_mode()
+        return super().update(**kwargs)
+
+    def delete(self) -> tuple[int, dict[str, int]]:
+        """Guard ``delete()`` with strict mode check."""
+        self._check_strict_mode()
+        return super().delete()
+
+    def iterator(self, chunk_size: int | None = None) -> Any:
+        """Guard ``iterator()`` with strict mode check."""
+        self._check_strict_mode()
+        return super().iterator(chunk_size=chunk_size)
+
+    def bulk_create(
+        self,
+        objs: Any,
+        batch_size: int | None = None,
+        ignore_conflicts: bool = False,
+        update_conflicts: bool = False,
+        update_fields: Any = None,
+        unique_fields: Any = None,
+    ) -> list[Any]:
+        """Guard ``bulk_create()`` with strict mode check."""
+        self._check_strict_mode()
+        return super().bulk_create(
+            objs,
+            batch_size=batch_size,
+            ignore_conflicts=ignore_conflicts,
+            update_conflicts=update_conflicts,
+            update_fields=update_fields,
+            unique_fields=unique_fields,
+        )
+
+    def bulk_update(
+        self,
+        objs: Any,
+        fields: Any,
+        batch_size: int | None = None,
+    ) -> int:
+        """Guard ``bulk_update()`` with strict mode check."""
+        self._check_strict_mode()
+        return super().bulk_update(objs, fields, batch_size=batch_size)
+
+    def get(self, *args: Any, **kwargs: Any) -> Any:
+        """Guard ``get()`` with strict mode check."""
+        self._check_strict_mode()
+        return super().get(*args, **kwargs)
+
+    def first(self) -> Any:
+        """Guard ``first()`` with strict mode check."""
+        self._check_strict_mode()
+        return super().first()
+
+    def last(self) -> Any:
+        """Guard ``last()`` with strict mode check."""
+        self._check_strict_mode()
+        return super().last()
+
     def _fetch_all(self) -> None:
         """Set GUC variables just before query execution.
 
@@ -235,6 +355,7 @@ class TenantQuerySet(models.QuerySet):  # type: ignore[type-arg]
         that any querysets created during fetch (e.g., prefetch queries,
         deferred loads) benefit from auto-scope.
         """
+        self._check_strict_mode()
         if self._rls_user is not None:
             conf = rls_tenants_config
             db_alias = self.db

--- a/django_rls_tenants/tenants/middleware.py
+++ b/django_rls_tenants/tenants/middleware.py
@@ -15,7 +15,12 @@ from django.utils.deprecation import MiddlewareMixin
 from django_rls_tenants.rls.guc import clear_guc, set_guc
 from django_rls_tenants.tenants.conf import rls_tenants_config
 from django_rls_tenants.tenants.context import _resolve_user_guc_vars
-from django_rls_tenants.tenants.state import reset_current_tenant_id, set_current_tenant_id
+from django_rls_tenants.tenants.state import (
+    reset_current_tenant_id,
+    reset_rls_context_active,
+    set_current_tenant_id,
+    set_rls_context_active,
+)
 
 if TYPE_CHECKING:
     from django.http import HttpRequest, HttpResponse
@@ -94,6 +99,11 @@ class RLSTenantMiddleware(MiddlewareMixin):
         conf = rls_tenants_config
         user: Any = request.user
 
+        # Track tokens so the except branch can reset via token (not
+        # push a new value) when the ContextVar was already set before
+        # the failure.
+        tenant_token: Token[int | str | None] | None = None
+        active_token: Token[bool] | None = None
         try:
             guc_vars = _resolve_user_guc_vars(user, conf)
             self._set_gucs_on_all_databases(guc_vars, conf)
@@ -103,14 +113,29 @@ class RLSTenantMiddleware(MiddlewareMixin):
             # rather than the string GUC representation, so that
             # get_current_tenant_id() returns a consistent type.
             if not user.is_tenant_admin:
-                token = set_current_tenant_id(user.rls_tenant_id)
+                tenant_token = set_current_tenant_id(user.rls_tenant_id)
             else:
-                token = set_current_tenant_id(None)
-            setattr(request, "_rls_tenant_token", token)  # noqa: B010  -- dynamic attr on HttpRequest
+                tenant_token = set_current_tenant_id(None)
+            setattr(request, "_rls_tenant_token", tenant_token)  # noqa: B010  -- dynamic attr on HttpRequest
+
+            # Mark RLS context as active for strict mode. This
+            # distinguishes "middleware set context" from "no context".
+            active_token = set_rls_context_active(True)
+            setattr(request, "_rls_context_active_token", active_token)  # noqa: B010  -- dynamic attr on HttpRequest
             _mark_gucs_set()
         except Exception:
             logger.exception("Failed to set RLS GUC variables, clearing to prevent leak")
-            set_current_tenant_id(None)
+            # Reset via token when available to avoid stacking unreset
+            # ContextVar values; fall back to set() when the token was
+            # never created (error occurred before set call).
+            if isinstance(tenant_token, Token):
+                reset_current_tenant_id(tenant_token)
+            else:
+                set_current_tenant_id(None)
+            if isinstance(active_token, Token):
+                reset_rls_context_active(active_token)
+            else:
+                set_rls_context_active(False)
             _clear_gucs_on_all_databases(conf)
             raise
 
@@ -173,7 +198,7 @@ class RLSTenantMiddleware(MiddlewareMixin):
 
     @staticmethod
     def _cleanup_rls_state(request: HttpRequest) -> None:
-        """Reset ContextVar (via token if available) and clear GUCs.
+        """Reset ContextVars (via tokens if available) and clear GUCs.
 
         Clears GUCs on all configured database aliases. Skips database
         round-trips for requests where GUCs were never set (e.g.,
@@ -189,6 +214,13 @@ class RLSTenantMiddleware(MiddlewareMixin):
             # Fallback: no token stored (unauthenticated request or error
             # during process_request before token was saved).
             set_current_tenant_id(None)
+
+        active_token = getattr(request, "_rls_context_active_token", None)
+        if isinstance(active_token, Token):
+            reset_rls_context_active(active_token)
+        else:
+            set_rls_context_active(False)
+
         if not _were_gucs_set():
             return
         conf = rls_tenants_config

--- a/django_rls_tenants/tenants/state.py
+++ b/django_rls_tenants/tenants/state.py
@@ -1,4 +1,4 @@
-"""Tenant state for automatic query scoping.
+"""Tenant state for automatic query scoping and strict mode.
 
 Relies on Python's ``contextvars.ContextVar`` for thread and async-task
 isolation.
@@ -9,6 +9,11 @@ Uses ``contextvars.ContextVar`` to store the current tenant ID so that
 indexes, eliminating the sequential scan penalty that occurs when relying
 solely on RLS ``current_setting()`` calls (which are not leakproof).
 
+A second ``ContextVar`` (``_rls_context_active``) tracks whether *any*
+RLS context is active (tenant or admin). This is needed by strict mode
+to distinguish "no context" from "admin context" -- both have
+``_current_tenant_id=None``, but only the former should raise.
+
 The state is set/restored by ``tenant_context()``, ``admin_context()``,
 and ``RLSTenantMiddleware``. Users should not need to call these functions
 directly -- use the context managers or middleware instead.
@@ -17,6 +22,8 @@ directly -- use the context managers or middleware instead.
 from __future__ import annotations
 
 from contextvars import ContextVar, Token
+
+# ---- Tenant ID state ----
 
 _current_tenant_id: ContextVar[int | str | None] = ContextVar(
     "rls_current_tenant_id", default=None
@@ -55,3 +62,43 @@ def reset_current_tenant_id(token: Token[int | str | None]) -> None:
         token: The token returned by the corresponding ``set_current_tenant_id()`` call.
     """
     _current_tenant_id.reset(token)
+
+
+# ---- RLS context active flag (strict mode) ----
+
+_rls_context_active: ContextVar[bool] = ContextVar("rls_context_active", default=False)
+
+
+def get_rls_context_active() -> bool:
+    """Return whether an RLS context is currently active.
+
+    An RLS context is active when ``tenant_context()``,
+    ``admin_context()``, or ``RLSTenantMiddleware`` has established
+    a context for the current execution scope. Used by strict mode
+    to distinguish "no context" from "admin context".
+
+    Returns:
+        ``True`` if an RLS context is active.
+    """
+    return _rls_context_active.get()
+
+
+def set_rls_context_active(active: bool) -> Token[bool]:
+    """Set the RLS context active flag.
+
+    Args:
+        active: Whether an RLS context is active.
+
+    Returns:
+        A ``Token`` for restoring the previous value.
+    """
+    return _rls_context_active.set(active)
+
+
+def reset_rls_context_active(token: Token[bool]) -> None:
+    """Restore the previous RLS context active state.
+
+    Args:
+        token: The token returned by ``set_rls_context_active()``.
+    """
+    _rls_context_active.reset(token)

--- a/docs/advanced/architecture.md
+++ b/docs/advanced/architecture.md
@@ -48,8 +48,8 @@ The upper layer builds Django multitenancy on top of `rls/`:
 | `tenants/bypass.py` | `set_bypass_flag()`, `clear_bypass_flag()`, `bypass_flag()` |
 | `tenants/testing.py` | Test helpers: `rls_bypass`, `rls_as_tenant`, assertion functions |
 | `tenants/types.py` | `TenantUser` protocol |
-| `tenants/state.py` | `get_current_tenant_id()`, `set_current_tenant_id()`, `reset_current_tenant_id()` -- `ContextVar`-based tenant state for auto-scoping |
-| `tenants/checks.py` | Django system checks (W001--W005) |
+| `tenants/state.py` | `get_current_tenant_id()`, `set_current_tenant_id()`, `reset_current_tenant_id()` -- `ContextVar`-based tenant state for auto-scoping. Also `get_rls_context_active()`, `set_rls_context_active()`, `reset_rls_context_active()` -- tracks whether any RLS context is active (used by strict mode) |
+| `tenants/checks.py` | Django system checks (W001--W007) |
 
 ### Import Boundary
 

--- a/docs/advanced/migration-guide.md
+++ b/docs/advanced/migration-guide.md
@@ -123,6 +123,82 @@ migration that assigns the correct tenant to each existing record.
 
 ## Upgrading django-rls-tenants
 
+### From 1.1.0 to 1.2.0
+
+This release has **one minor breaking change**: some `ValueError` exceptions have
+been replaced with custom exception types.
+
+#### What Changed
+
+1. **Custom exceptions**: The library introduces a custom exception hierarchy in
+   `django_rls_tenants.exceptions`. `tenant_context(None)` and
+   `_resolve_user_guc_vars()` now raise `NoTenantContextError` instead of
+   `ValueError`. `RLSTenantsConfig._get()` now raises `RLSConfigurationError`
+   instead of `ValueError`. If you catch `ValueError` from these functions,
+   update your except clauses. Both are subclasses of `RLSTenantError`, which
+   is a subclass of `Exception`.
+
+2. **Multi-database GUC support**: The middleware now sets GUC variables on all
+   database aliases listed in `RLS_TENANTS["DATABASES"]` (default: `["default"]`).
+   No changes needed for single-database setups.
+
+3. **Strict mode** (`STRICT_MODE=True`): An opt-in setting that raises
+   `NoTenantContextError` when queries execute without an active RLS context.
+   Off by default -- existing behavior is unchanged.
+
+4. **New public API**: `get_rls_context_active()`, `set_rls_context_active()`,
+   `reset_rls_context_active()` for tracking whether an RLS context is active.
+   These are primarily used internally by strict mode but are available for
+   custom middleware implementations.
+
+#### Upgrade Steps
+
+1. **Update the package**:
+
+    ```bash
+    pip install --upgrade django-rls-tenants
+    ```
+
+2. **Update exception handling** (if applicable):
+
+    ```python
+    # Before (1.1.0)
+    from django_rls_tenants import tenant_context
+    try:
+        with tenant_context(tenant_id=None):
+            ...
+    except ValueError:
+        ...
+
+    # After (1.2.0)
+    from django_rls_tenants import tenant_context, NoTenantContextError
+    try:
+        with tenant_context(tenant_id=None):
+            ...
+    except NoTenantContextError:
+        ...
+    ```
+
+3. **Optional: enable multi-database support**:
+
+    ```python
+    RLS_TENANTS = {
+        "TENANT_MODEL": "myapp.Tenant",
+        "DATABASES": ["default", "replica"],
+    }
+    ```
+
+4. **Optional: enable strict mode**:
+
+    ```python
+    RLS_TENANTS = {
+        "TENANT_MODEL": "myapp.Tenant",
+        "STRICT_MODE": True,
+    }
+    ```
+
+5. **Verify**: run `python manage.py check` and `python manage.py check_rls`.
+
 ### From 1.0.0 to 1.1.0
 
 This release has **no breaking changes**. All existing code continues to work without

--- a/docs/advanced/security.md
+++ b/docs/advanced/security.md
@@ -153,12 +153,48 @@ See [Connection Pooling](../guides/connection-pooling.md) for details.
 | Application-level logic bugs | RLS filters rows, not application behavior |
 | Denial of service | RLS does not rate-limit or throttle |
 
+## Strict Mode
+
+By default, queries without RLS context silently return zero rows (fail-closed).
+While this is secure, it can mask developer mistakes -- the classic "where did my
+data go?" debugging experience.
+
+`STRICT_MODE=True` adds an application-level guard: `TenantQuerySet` evaluation
+methods raise `NoTenantContextError` before the query reaches the database if no
+RLS context is active. This makes missing context failures **loud** instead of
+silent.
+
+```python title="settings.py"
+RLS_TENANTS = {
+    "TENANT_MODEL": "myapp.Tenant",
+    "STRICT_MODE": True,
+}
+```
+
+**What counts as "active context":**
+
+- `tenant_context()` or `admin_context()` context managers
+- `RLSTenantMiddleware` (for authenticated requests)
+- `for_user()` on the queryset
+
+**Guarded methods:** `_fetch_all()` (iteration), `count()`, `exists()`,
+`aggregate()`, `update()`, `delete()`, `iterator()`, `bulk_create()`,
+`bulk_update()`, `get()`, `first()`, `last()`.
+
+!!! note
+    Strict mode does **not** change database-level behavior. RLS policies
+    continue to enforce fail-closed isolation regardless. Strict mode is an
+    additional application-level safety net that surfaces mistakes earlier.
+
+See [Configuration](../getting-started/configuration.md#strict_mode) for setup.
+
 ## Recommendations
 
 1. **Use a non-superuser database role** in production.
-2. **Enable `USE_LOCAL_SET`** if using connection pooling.
-3. **Use UUIDs** for tenant PKs if sequence-based leaks are a concern.
-4. **Include tenant FK in unique constraints** that should be per-tenant.
-5. **Run `check_rls`** in CI to verify policies exist.
-6. **Audit bypass usage** (`admin_context`, `bypass_flag`) regularly.
-7. **Test fail-closed behavior** with `assert_rls_blocks_without_context`.
+2. **Enable `STRICT_MODE`** in development and staging to catch missing context early.
+3. **Enable `USE_LOCAL_SET`** if using connection pooling.
+4. **Use UUIDs** for tenant PKs if sequence-based leaks are a concern.
+5. **Include tenant FK in unique constraints** that should be per-tenant.
+6. **Run `check_rls`** in CI to verify policies exist.
+7. **Audit bypass usage** (`admin_context`, `bypass_flag`) regularly.
+8. **Test fail-closed behavior** with `assert_rls_blocks_without_context`.

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -78,6 +78,8 @@
 - **Dual-layer filtering**: ORM-level `WHERE` enables composite indexes, while
   RLS provides a database-level safety net.
 - **Fail-closed**: missing tenant context = zero rows, not all rows.
+- **Optional strict mode**: `STRICT_MODE=True` raises `NoTenantContextError` on
+  unscoped queries, turning silent empty results into loud errors.
 - **Single schema**: standard Django migrations run once, not once per tenant.
 - **No catalog bloat**: 1000 tenants ≈ same DB footprint as 1 tenant.
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -9,6 +9,7 @@ settings module.
 RLS_TENANTS = {
     "TENANT_MODEL": "myapp.Tenant",
     "DATABASES": ["default"],
+    "STRICT_MODE": False,
     "TENANT_FK_FIELD": "tenant",
     "GUC_PREFIX": "rls",
     "USER_PARAM_NAME": "as_user",
@@ -59,6 +60,48 @@ that don't exist when the middleware runs.
 !!! warning
     Each alias must exist in Django's `DATABASES` setting. A typo (e.g., `"replca"`)
     will trigger system check `W006` at startup and cause runtime errors.
+
+### `STRICT_MODE`
+
+| | |
+|---|---|
+| **Type** | `bool` |
+| **Default** | `False` |
+
+When `True`, `TenantQuerySet` evaluation methods raise `NoTenantContextError`
+if no RLS context is active. This catches accidental queries outside a
+`tenant_context()`, `admin_context()`, `for_user()`, or `RLSTenantMiddleware`
+scope at the point of query execution rather than silently returning zero rows.
+
+**Guarded methods:** `_fetch_all()` (iteration), `count()`, `exists()`,
+`aggregate()`, `update()`, `delete()`, `iterator()`, `bulk_create()`,
+`bulk_update()`, `get()`, `first()`, `last()`.
+
+```python
+RLS_TENANTS = {
+    "TENANT_MODEL": "myapp.Tenant",
+    "STRICT_MODE": True,  # Recommended for development
+}
+```
+
+**Recommended usage:** Enable in development and staging to surface missing
+context early. In production, the fail-closed behavior (zero rows) is still
+the safety net, but strict mode makes the failure loud instead of silent.
+
+```python title="settings.py"
+import os
+
+RLS_TENANTS = {
+    "TENANT_MODEL": "myapp.Tenant",
+    "STRICT_MODE": os.environ.get("DJANGO_ENV") != "production",
+}
+```
+
+!!! note
+    Strict mode does **not** change the database-level behavior. RLS policies
+    continue to enforce fail-closed isolation regardless of this setting. Strict
+    mode adds an application-level check that raises before the query reaches
+    the database.
 
 ### `TENANT_FK_FIELD`
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -87,8 +87,14 @@ RLS_TENANTS = {
     "USER_PARAM_NAME": "as_user",      # Parameter name for @with_rls_context
     "TENANT_PK_TYPE": "int",           # SQL cast type: "int", "bigint", or "uuid"
     "USE_LOCAL_SET": False,            # Use SET LOCAL (for connection pooling)
+    "DATABASES": ["default"],          # Database aliases to set GUCs on
+    "STRICT_MODE": False,              # Raise on queries without tenant context
 }
 ```
+
+!!! tip
+    Enable `STRICT_MODE` during development to catch accidental unscoped queries
+    early. See [Configuration](configuration.md#strict_mode) for details.
 
 See [Configuration](configuration.md) for a detailed explanation of each setting.
 
@@ -148,7 +154,7 @@ If any policies are missing, the command exits with a non-zero status and lists 
 
 ## What's Next?
 
-- [Configuration](configuration.md) -- understand all 6 settings.
+- [Configuration](configuration.md) -- understand all 8 settings.
 - [Protecting Models](../guides/protecting-models.md) -- customize FK fields and constraints.
 - [Context Managers](../guides/context-managers.md) -- use `tenant_context` and `admin_context` in scripts.
 - [Testing](../guides/testing.md) -- test helpers for RLS verification.

--- a/docs/guides/context-managers.md
+++ b/docs/guides/context-managers.md
@@ -173,6 +173,36 @@ create_order(request, as_user=tenant_user)
 create_order(request, tenant_user)  # also works (positional)
 ```
 
+## Strict Mode
+
+When `STRICT_MODE=True`, queries on RLS-protected models raise
+`NoTenantContextError` if no RLS context is active. Both `tenant_context()` and
+`admin_context()` establish an active context, so queries inside these blocks
+always pass the strict mode check.
+
+```python
+from django_rls_tenants import tenant_context, admin_context, NoTenantContextError
+
+# Without context -- raises NoTenantContextError (strict mode)
+try:
+    Order.objects.count()  # NoTenantContextError
+except NoTenantContextError:
+    pass
+
+# With context -- works normally
+with tenant_context(tenant_id=42):
+    Order.objects.count()  # OK
+
+with admin_context():
+    Order.objects.count()  # OK
+```
+
+The `@with_rls_context` decorator also establishes an active context when a valid
+user argument is provided, so decorated functions pass the strict mode check.
+
+See [Configuration](../getting-started/configuration.md#strict_mode) for setup
+instructions.
+
 ## Multi-Database Support
 
 All context managers accept a `using` parameter for multi-database setups:

--- a/docs/guides/management-commands.md
+++ b/docs/guides/management-commands.md
@@ -112,3 +112,9 @@ class Command(BaseCommand):
     Without a context manager, queries against RLS-protected tables will return
     zero rows (fail-closed). This is intentional -- it prevents accidental
     cross-tenant data access in scripts.
+
+!!! tip
+    With `STRICT_MODE=True`, queries without a context manager raise
+    `NoTenantContextError` instead of silently returning empty results. This is
+    especially useful during development to catch management commands that forget
+    to set a context.

--- a/docs/guides/middleware.md
+++ b/docs/guides/middleware.md
@@ -39,24 +39,28 @@ MIDDLEWARE = [
    cleaned up before the exception propagates.
 5. Sets the internal `ContextVar` state for automatic query scoping (tenant users get
    auto-scoped queries; admin users and unauthenticated requests do not).
-6. Marks a `ContextVar` flag that GUCs were set (used by the safety-net signal handler).
+6. Sets `_rls_context_active=True` to mark that an RLS context is active. This is used
+   by strict mode to distinguish "middleware set context" from "no context at all".
+7. Marks a `ContextVar` flag that GUCs were set (used by the safety-net signal handler).
 
 ### Response Phase (`process_response`)
 
-1. Clears the `ContextVar` auto-scope state to prevent cross-request leaks.
-2. If `USE_LOCAL_SET` is `False` (default): clears both GUC variables on **all
+1. Resets the `_rls_context_active` flag (via saved token) to prevent cross-request leaks.
+2. Clears the `ContextVar` auto-scope state to prevent cross-request leaks.
+3. If `USE_LOCAL_SET` is `False` (default): clears both GUC variables on **all
    configured database aliases** to prevent cross-request leaks on persistent connections.
-3. If `USE_LOCAL_SET` is `True`: GUCs are automatically cleared at transaction end
+4. If `USE_LOCAL_SET` is `True`: GUCs are automatically cleared at transaction end
    (by PostgreSQL), so explicit cleanup is skipped.
-4. Clears the `ContextVar` GUC flag.
+5. Clears the `ContextVar` GUC flag.
 
 ### Exception Phase (`process_exception`)
 
 If a view raises an unhandled exception, `process_response` may not run (depending
 on middleware ordering). The `process_exception` handler ensures cleanup still happens:
 
-1. Resets the `ContextVar` auto-scope state (via the saved token or fallback to `None`).
-2. Clears GUC variables (same logic as `process_response`).
+1. Resets the `_rls_context_active` flag (via saved token or fallback to `False`).
+2. Resets the `ContextVar` auto-scope state (via the saved token or fallback to `None`).
+3. Clears GUC variables (same logic as `process_response`).
 
 This prevents `ContextVar` leaks that could affect subsequent requests on the same
 thread (WSGI) or async task (ASGI).
@@ -87,18 +91,22 @@ RLSTenantMiddleware.process_request()
     │   └── SET rls.is_admin = 'true'
     │       CLEAR rls.current_tenant
     │       SET auto-scope state = None (no filter)
+    │       SET _rls_context_active = True
     │
     └── user.is_tenant_admin == False
         └── SET rls.current_tenant = str(tenant_id)
             SET rls.is_admin = 'false'
             SET auto-scope state = tenant_id
+            SET _rls_context_active = True
     │
     ▼
 View executes (queries auto-scoped + filtered by RLS)
+  (strict mode: queries pass because _rls_context_active = True)
     │
     ▼
 RLSTenantMiddleware.process_response()  (or process_exception on error)
     │
+    ├── RESET _rls_context_active (via saved token)
     ├── RESET auto-scope ContextVar (via saved token)
     ├── USE_LOCAL_SET == False → CLEAR both GUCs
     └── USE_LOCAL_SET == True  → no-op (transaction handles cleanup)
@@ -144,6 +152,17 @@ The middleware is API-agnostic. It works identically for:
 - Any other Django-compatible request handler
 
 The only requirement is that `request.user` satisfies the `TenantUser` protocol.
+
+## Strict Mode
+
+The middleware sets `_rls_context_active=True` for authenticated requests, which
+satisfies the strict mode check. Unauthenticated requests do **not** set this
+flag -- if strict mode is enabled, queries in unauthenticated views will raise
+`NoTenantContextError` rather than silently returning zero rows.
+
+This is the intended behavior: strict mode surfaces missing context at the point
+of query execution, making it easier to identify views that should require
+authentication.
 
 ## Using Without Middleware
 

--- a/docs/guides/protecting-models.md
+++ b/docs/guides/protecting-models.md
@@ -123,6 +123,34 @@ is not leakproof, so the planner cannot push the RLS predicate into index scans.
 The automatic ORM-level `WHERE tenant_id = X` filter enables composite indexes,
 eliminating sequential scan penalties at scale.
 
+## Strict Mode Guard
+
+When `STRICT_MODE=True` in your `RLS_TENANTS` configuration, `TenantQuerySet`
+evaluation methods raise `NoTenantContextError` if no RLS context is active.
+This catches accidental unscoped queries at the point of execution:
+
+```python
+from django_rls_tenants import NoTenantContextError
+
+# Without context -- raises in strict mode
+Order.objects.count()       # NoTenantContextError
+Order.objects.all().first() # NoTenantContextError
+Order.objects.filter(active=True).exists()  # NoTenantContextError
+
+# With context -- works normally
+with tenant_context(tenant_id=42):
+    Order.objects.count()   # OK
+```
+
+The following queryset methods are guarded: iteration (`_fetch_all()`), `count()`,
+`exists()`, `aggregate()`, `update()`, `delete()`, `iterator()`, `bulk_create()`,
+`bulk_update()`, `get()`, `first()`, `last()`.
+
+Queryset *construction* (e.g., `Order.objects.filter(...)`) does not trigger the
+check -- only evaluation does. This matches Django's lazy queryset philosophy.
+
+See [Configuration](../getting-started/configuration.md#strict_mode) for setup.
+
 ## Using for_user()
 
 `for_user()` is still available and works as before. It scopes queries to a specific

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -187,6 +187,36 @@ def test_rls_with_transactions(tenant_a):
     ...
 ```
 
+## Strict Mode in Tests
+
+When `STRICT_MODE=True`, any query on an RLS-protected model without an active
+context raises `NoTenantContextError`. This affects test setup code that queries
+models outside a context.
+
+Use `rls_bypass()` (which wraps `admin_context()`) or `rls_as_tenant()` in
+fixture and setup code:
+
+```python
+@pytest.fixture
+def sample_data():
+    # rls_bypass establishes an active context -- passes strict mode check
+    with rls_bypass():
+        tenant = Tenant.objects.create(name="Test")
+        Order.objects.create(tenant=tenant, title="Order 1", amount=100)
+    return tenant
+```
+
+To explicitly test that strict mode raises, use `pytest.raises`:
+
+```python
+from django_rls_tenants import NoTenantContextError
+
+@override_settings(RLS_TENANTS={**RLS_SETTINGS, "STRICT_MODE": True})
+def test_strict_mode_raises_without_context():
+    with pytest.raises(NoTenantContextError, match="strict mode"):
+        Order.objects.count()
+```
+
 ## Multi-Database Testing
 
 All test helpers accept a `using` parameter:

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,7 @@ policy. The database itself becomes the trust boundary.
 - **Database-enforced isolation** -- RLS policies apply to every query, not just ORM calls.
 - **Automatic query scoping** -- queries are filtered at both ORM and database levels for defense-in-depth.
 - **Fail-closed by default** -- missing tenant context returns zero rows, never leaks data.
+- **Optional strict mode** -- `STRICT_MODE=True` raises `NoTenantContextError` on unscoped queries, turning silent empty results into loud errors during development.
 - **Single schema, single database** -- no schema-per-tenant overhead.
 - **API-agnostic** -- works with Django REST Framework, GraphQL, async views, management commands.
 - **Clean internal layering** -- generic `rls/` primitives separate from `tenants/` conveniences.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -19,8 +19,11 @@ from django_rls_tenants import (
     TenantUser,
     admin_context,
     get_current_tenant_id,
+    get_rls_context_active,
     reset_current_tenant_id,
+    reset_rls_context_active,
     set_current_tenant_id,
+    set_rls_context_active,
     tenant_context,
     with_rls_context,
 )
@@ -94,11 +97,21 @@ Django multitenancy built on top of the `rls/` primitives.
 
 ### State
 
+#### Tenant ID
+
 ::: django_rls_tenants.tenants.state.get_current_tenant_id
 
 ::: django_rls_tenants.tenants.state.set_current_tenant_id
 
 ::: django_rls_tenants.tenants.state.reset_current_tenant_id
+
+#### RLS Context Active (Strict Mode)
+
+::: django_rls_tenants.tenants.state.get_rls_context_active
+
+::: django_rls_tenants.tenants.state.set_rls_context_active
+
+::: django_rls_tenants.tenants.state.reset_rls_context_active
 
 ### Middleware
 

--- a/example/README.md
+++ b/example/README.md
@@ -63,7 +63,18 @@ Open **<http://localhost:8000>** and log in with any demo account:
    docker compose exec web python manage.py check_rls
    ```
 
-7. **Django admin** -- Visit <http://localhost:8000/admin/>
+7. **Strict mode** -- The demo has `STRICT_MODE=True` in `RLS_TENANTS`. Try
+   querying an RLS-protected model in `manage.py shell` without establishing
+   a tenant context:
+   ```python
+   from notes.models import Note
+   Note.objects.count()  # -> raises NoTenantContextError
+   ```
+   This catches accidental unscoped queries during development. The
+   `note_delete` view in `notes/views.py` shows how to handle the error
+   gracefully.
+
+8. **Django admin** -- Visit <http://localhost:8000/admin/>
    (`admin@example.com` / `admin1234`).
 
 ## Library Features Demonstrated
@@ -79,7 +90,10 @@ Open **<http://localhost:8000>** and log in with any demo account:
 | `admin_context()` | `seed_demo.py` -- bulk data creation bypassing RLS |
 | `tenant_context()` | `seed_demo.py` -- programmatic tenant scoping for verification |
 | `check_rls` command | `docker-compose.yml` -- runs after migrations |
+| `STRICT_MODE` | `demo/settings.py` -- raises `NoTenantContextError` on unscoped queries |
+| `NoTenantContextError` handling | `notes/views.py` -- graceful handling in view code |
 | Testing utilities | `tests/test_rls.py` -- `rls_bypass`, `rls_as_tenant`, assert helpers |
+| Strict mode tests | `tests/test_rls.py` -- `TestStrictMode` class |
 
 ## How It Works
 

--- a/example/accounts/models.py
+++ b/example/accounts/models.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.contrib.auth.models import AbstractUser
 from django.db import models
 
@@ -13,11 +15,11 @@ class User(AbstractUser):
     is_tenant_admin = models.BooleanField(default=False)
 
     @property
-    def rls_tenant_id(self):
-        return self.tenant_id
+    def rls_tenant_id(self) -> int | None:
+        return self.tenant_id  # type: ignore[return-value]
 
-    def __str__(self):
-        label = self.email or self.username
+    def __str__(self) -> str:
+        label: str = self.email or self.username
         if self.tenant:
             return f"{label} ({self.tenant.name})"
         return f"{label} (admin)"

--- a/example/demo/settings.py
+++ b/example/demo/settings.py
@@ -63,6 +63,12 @@ RLS_TENANTS = {
     "TENANT_MODEL": "tenants.Tenant",
     "TENANT_FK_FIELD": "tenant",
     "TENANT_PK_TYPE": "int",
+    # Strict mode: raise NoTenantContextError when querying RLS-protected
+    # models without an active tenant context (instead of silently returning
+    # empty results). Recommended for development/staging.
+    "STRICT_MODE": True,
+    # "DATABASES": ["default"],     # Database aliases for GUC setup (default: ["default"])
+    # "USE_LOCAL_SET": False,       # Use SET LOCAL instead of set_config (default: False)
 }
 
 TEMPLATES = [

--- a/example/notes/views.py
+++ b/example/notes/views.py
@@ -1,5 +1,8 @@
 from django.contrib.auth.decorators import login_required
+from django.http import HttpResponseServerError
 from django.shortcuts import get_object_or_404, redirect, render
+
+from django_rls_tenants import NoTenantContextError
 
 from .models import Category, Note
 from .services import get_note_stats
@@ -42,7 +45,13 @@ def note_create(request):
 
 @login_required
 def note_delete(request, pk):
-    note = get_object_or_404(Note, pk=pk)
+    # Demonstrates handling NoTenantContextError gracefully.
+    # With STRICT_MODE=True, queries without tenant context raise
+    # NoTenantContextError instead of silently returning empty results.
+    try:
+        note = get_object_or_404(Note, pk=pk)
+    except NoTenantContextError:
+        return HttpResponseServerError("Tenant context required to access notes.")
     if request.method == "POST":
         note.delete()
     return redirect("note_list")

--- a/example/tests/test_rls.py
+++ b/example/tests/test_rls.py
@@ -3,10 +3,15 @@
 Shows how to use ``rls_bypass``, ``rls_as_tenant``, ``assert_rls_enabled``,
 ``assert_rls_policy_exists``, and ``assert_rls_blocks_without_context``
 in a real project's test suite.
+
+Also demonstrates strict mode: when ``STRICT_MODE=True``, querying
+RLS-protected models without an active tenant context raises
+``NoTenantContextError`` instead of silently returning empty results.
 """
 
 import pytest
 
+from django_rls_tenants import NoTenantContextError
 from django_rls_tenants.tenants.testing import (
     assert_rls_blocks_without_context,
     assert_rls_enabled,
@@ -41,7 +46,28 @@ class TestRLSPolicies:
 
 
 class TestFailClosed:
-    """Verify that queries without RLS context return zero rows."""
+    """Verify that queries without RLS context return zero rows.
+
+    These tests verify the **database-level** RLS enforcement (PostgreSQL
+    returns zero rows when no GUC context is set). We temporarily disable
+    ``STRICT_MODE`` so the ORM-level guard does not fire first -- this
+    isolates the database-layer behavior.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _disable_strict_mode(self, settings):
+        """Disable strict mode so database-layer RLS is tested in isolation.
+
+        Clears the config cache so ``RLSTenantsConfig`` re-reads the
+        overridden setting, and restores it after the test.
+        """
+        from django_rls_tenants.tenants.conf import rls_tenants_config
+
+        old_cache = rls_tenants_config._config_cache  # noqa: SLF001
+        settings.RLS_TENANTS = {**settings.RLS_TENANTS, "STRICT_MODE": False}
+        rls_tenants_config._config_cache = None  # noqa: SLF001
+        yield
+        rls_tenants_config._config_cache = old_cache  # noqa: SLF001
 
     def test_notes_blocked_without_context(self, tenant_acme):
         from notes.models import Note
@@ -116,3 +142,48 @@ class TestTenantIsolation:
             assert len(notes) == 1
             assert notes[0].category.name == "Eng"
             assert notes[0].category.tenant_id == tenant_acme.pk
+
+
+# ── Strict mode tests ─────────────────────────────────────────────
+
+
+class TestStrictMode:
+    """Verify strict mode raises NoTenantContextError on unscoped queries.
+
+    When ``STRICT_MODE=True`` in ``RLS_TENANTS``, querying an
+    RLS-protected model without an active tenant context raises
+    ``NoTenantContextError`` instead of silently returning zero rows.
+    This catches accidental unscoped queries during development.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _ensure_strict_mode(self):
+        """Clear config cache so STRICT_MODE=True is read from settings."""
+        from django_rls_tenants.tenants.conf import rls_tenants_config
+
+        rls_tenants_config._config_cache = None  # noqa: SLF001
+        yield
+        rls_tenants_config._config_cache = None  # noqa: SLF001
+
+    def test_query_without_context_raises(self):
+        """Querying without tenant context raises NoTenantContextError."""
+        from notes.models import Note
+
+        with pytest.raises(NoTenantContextError, match="strict mode"):
+            Note.objects.count()
+
+    def test_query_with_context_succeeds(self, tenant_acme):
+        """Querying with tenant context works normally."""
+        from notes.models import Note
+
+        with rls_as_tenant(tenant_acme.pk):
+            # Should not raise -- context is active
+            assert Note.objects.count() == 0
+
+    def test_admin_bypass_succeeds(self):
+        """Admin bypass context is not blocked by strict mode."""
+        from notes.models import Note
+
+        with rls_bypass():
+            # Should not raise -- admin context is active
+            assert Note.objects.count() >= 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ from django.db import connection
 
 from django_rls_tenants.rls.guc import clear_guc
 from django_rls_tenants.tenants.context import admin_context
-from django_rls_tenants.tenants.state import set_current_tenant_id
+from django_rls_tenants.tenants.state import set_current_tenant_id, set_rls_context_active
 from tests.test_app.models import (
     Document,
     Order,
@@ -43,6 +43,7 @@ def _clear_gucs_after_test(db):
     yield
     try:
         set_current_tenant_id(None)
+        set_rls_context_active(False)
     finally:
         for name in _GUC_NAMES_TO_CLEAR:
             with contextlib.suppress(Exception):

--- a/tests/test_tenants/test_conf.py
+++ b/tests/test_tenants/test_conf.py
@@ -110,6 +110,18 @@ class TestRLSTenantsConfig:
             conf = RLSTenantsConfig()
             assert conf.DATABASES == ["default", "replica"]
 
+    def test_strict_mode_default(self):
+        """STRICT_MODE defaults to False."""
+        with override_settings(RLS_TENANTS={"TENANT_MODEL": "x.Y"}):
+            conf = RLSTenantsConfig()
+            assert conf.STRICT_MODE is False
+
+    def test_strict_mode_true(self):
+        """STRICT_MODE reads True from settings."""
+        with override_settings(RLS_TENANTS={"TENANT_MODEL": "x.Y", "STRICT_MODE": True}):
+            conf = RLSTenantsConfig()
+            assert conf.STRICT_MODE is True
+
     def test_unknown_key_warns(self):
         """Unrecognized keys in RLS_TENANTS emit a UserWarning."""
         with override_settings(

--- a/tests/test_tenants/test_managers.py
+++ b/tests/test_tenants/test_managers.py
@@ -3,15 +3,22 @@
 from __future__ import annotations
 
 from decimal import Decimal
+from unittest.mock import MagicMock
 
 import pytest
 from django.core.exceptions import FieldError
+from django.db.models import Sum
+from django.test import override_settings
 
+from django_rls_tenants.exceptions import NoTenantContextError
 from django_rls_tenants.rls.guc import get_guc
+from django_rls_tenants.tenants.conf import rls_tenants_config
 from django_rls_tenants.tenants.context import admin_context, tenant_context
 from django_rls_tenants.tenants.managers import _is_rls_protected, _resolve_related_model
+from django_rls_tenants.tenants.middleware import RLSTenantMiddleware
 from django_rls_tenants.tenants.state import (
     get_current_tenant_id,
+    get_rls_context_active,
     reset_current_tenant_id,
     set_current_tenant_id,
 )
@@ -444,3 +451,244 @@ class TestResolveRelatedModel:
         """Returns None for a non-relation field (e.g., CharField)."""
         result = _resolve_related_model(Order, "product")
         assert result is None
+
+
+# ---- Strict mode tests ----
+
+
+def _strict_settings():
+    """Return override_settings context for STRICT_MODE=True."""
+    return override_settings(
+        RLS_TENANTS={
+            "TENANT_MODEL": "test_app.Tenant",
+            "STRICT_MODE": True,
+        },
+    )
+
+
+@pytest.fixture
+def _strict_mode():
+    """Enable strict mode and reset config cache for the test."""
+    with _strict_settings():
+        rls_tenants_config._config_cache = None
+        rls_tenants_config._unknown_keys_checked = False
+        try:
+            yield
+        finally:
+            rls_tenants_config._config_cache = None
+            rls_tenants_config._unknown_keys_checked = False
+
+
+class TestStrictModeDisabled:
+    """Tests that strict mode off (default) preserves existing behavior."""
+
+    def test_no_context_returns_empty(self, sample_orders):
+        """Without context and strict mode off, queries return empty (fail-closed)."""
+        assert get_current_tenant_id() is None
+        qs = Order.objects.all()
+        # No strict mode error; just returns all rows (superuser test DB)
+        # or empty (if RLS enforced). The key point: no exception.
+        list(qs)
+
+
+class TestStrictModeRaises:
+    """Tests that strict mode raises NoTenantContextError on evaluation."""
+
+    @pytest.mark.usefixtures("_strict_mode")
+    def test_fetch_all_raises(self, sample_orders):
+        """list(qs) raises NoTenantContextError without context."""
+        qs = Order.objects.all()
+        with pytest.raises(NoTenantContextError, match="strict mode"):
+            list(qs)
+
+    @pytest.mark.usefixtures("_strict_mode")
+    def test_count_raises(self, sample_orders):
+        """qs.count() raises NoTenantContextError without context."""
+        qs = Order.objects.all()
+        with pytest.raises(NoTenantContextError, match="strict mode"):
+            qs.count()
+
+    @pytest.mark.usefixtures("_strict_mode")
+    def test_exists_raises(self, sample_orders):
+        """qs.exists() raises NoTenantContextError without context."""
+        qs = Order.objects.all()
+        with pytest.raises(NoTenantContextError, match="strict mode"):
+            qs.exists()
+
+    @pytest.mark.usefixtures("_strict_mode")
+    def test_aggregate_raises(self, sample_orders):
+        """qs.aggregate() raises NoTenantContextError without context."""
+        qs = Order.objects.all()
+        with pytest.raises(NoTenantContextError, match="strict mode"):
+            qs.aggregate(total=Sum("amount"))
+
+    @pytest.mark.usefixtures("_strict_mode")
+    def test_update_raises(self, sample_orders):
+        """qs.update() raises NoTenantContextError without context."""
+        qs = Order.objects.all()
+        with pytest.raises(NoTenantContextError, match="strict mode"):
+            qs.update(product="X")
+
+    @pytest.mark.usefixtures("_strict_mode")
+    def test_delete_raises(self, sample_orders):
+        """qs.delete() raises NoTenantContextError without context."""
+        qs = Order.objects.all()
+        with pytest.raises(NoTenantContextError, match="strict mode"):
+            qs.delete()
+
+    @pytest.mark.usefixtures("_strict_mode")
+    def test_get_raises(self, sample_orders):
+        """qs.get() raises NoTenantContextError without context."""
+        qs = Order.objects.all()
+        with pytest.raises(NoTenantContextError, match="strict mode"):
+            qs.get(pk=sample_orders["a1"].pk)
+
+    @pytest.mark.usefixtures("_strict_mode")
+    def test_first_raises(self, sample_orders):
+        """qs.first() raises NoTenantContextError without context."""
+        qs = Order.objects.all()
+        with pytest.raises(NoTenantContextError, match="strict mode"):
+            qs.first()
+
+    @pytest.mark.usefixtures("_strict_mode")
+    def test_last_raises(self, sample_orders):
+        """qs.last() raises NoTenantContextError without context."""
+        qs = Order.objects.all()
+        with pytest.raises(NoTenantContextError, match="strict mode"):
+            qs.last()
+
+    @pytest.mark.usefixtures("_strict_mode")
+    def test_iterator_raises(self, sample_orders):
+        """qs.iterator() raises NoTenantContextError without context."""
+        qs = Order.objects.all()
+        with pytest.raises(NoTenantContextError, match="strict mode"):
+            list(qs.iterator())
+
+    @pytest.mark.usefixtures("_strict_mode")
+    def test_bulk_create_raises(self, sample_orders, tenant_a):
+        """qs.bulk_create() raises NoTenantContextError without context."""
+        qs = Order.objects.all()
+        with pytest.raises(NoTenantContextError, match="strict mode"):
+            qs.bulk_create([Order(product="X", amount=1, tenant=tenant_a)])
+
+    @pytest.mark.usefixtures("_strict_mode")
+    def test_bulk_update_raises(self, sample_orders):
+        """qs.bulk_update() raises NoTenantContextError without context."""
+        qs = Order.objects.all()
+        with pytest.raises(NoTenantContextError, match="strict mode"):
+            qs.bulk_update([], fields=["product"])
+
+    @pytest.mark.usefixtures("_strict_mode")
+    def test_error_message_contains_model_name(self, sample_orders):
+        """Error message includes the model name for debugging."""
+        qs = Order.objects.all()
+        with pytest.raises(NoTenantContextError, match="Order"):
+            list(qs)
+
+
+class TestStrictModeAllowsContext:
+    """Tests that strict mode does NOT raise when context is properly set."""
+
+    @pytest.mark.usefixtures("_strict_mode")
+    def test_tenant_context_allows_query(self, sample_orders, tenant_a):
+        """No error when tenant_context() is active."""
+        with tenant_context(tenant_a.pk):
+            products = list(Order.objects.values_list("product", flat=True))
+            assert sorted(products) == ["Widget A1", "Widget A2"]
+
+    @pytest.mark.usefixtures("_strict_mode")
+    def test_admin_context_allows_query(self, sample_orders):
+        """No error when admin_context() is active."""
+        with admin_context():
+            count = Order.objects.count()
+            assert count == 3
+
+    @pytest.mark.usefixtures("_strict_mode")
+    def test_for_user_allows_query(self, sample_orders, tenant_a_user):
+        """No error when for_user() was called."""
+        qs = Order.objects.for_user(tenant_a_user)
+        products = list(qs.values_list("product", flat=True))
+        assert sorted(products) == ["Widget A1", "Widget A2"]
+
+    @pytest.mark.usefixtures("_strict_mode")
+    def test_middleware_allows_query(self, sample_orders, tenant_a_user):
+        """No error when middleware has set context."""
+        mw = RLSTenantMiddleware(get_response=lambda r: MagicMock())
+        request = MagicMock()
+        request.user = tenant_a_user
+        mw.process_request(request)
+        try:
+            products = list(Order.objects.values_list("product", flat=True))
+            assert sorted(products) == ["Widget A1", "Widget A2"]
+        finally:
+            mw.process_response(request, MagicMock())
+
+    @pytest.mark.usefixtures("_strict_mode")
+    def test_all_guarded_methods_pass_with_context(self, sample_orders, tenant_a):
+        """All guarded methods work within tenant_context()."""
+        with tenant_context(tenant_a.pk):
+            qs = Order.objects.all()
+            # These should all succeed without raising
+            list(qs)
+            Order.objects.all().count()
+            Order.objects.all().exists()
+            Order.objects.all().first()
+            Order.objects.all().last()
+            list(Order.objects.all().iterator())
+
+
+class TestStrictModeContextVarLifecycle:
+    """Tests that _rls_context_active is properly set and restored."""
+
+    def test_tenant_context_sets_active(self, db, tenant_a):
+        """tenant_context() sets _rls_context_active to True."""
+        assert get_rls_context_active() is False
+        with tenant_context(tenant_a.pk):
+            assert get_rls_context_active() is True
+        assert get_rls_context_active() is False
+
+    def test_admin_context_sets_active(self, db):
+        """admin_context() sets _rls_context_active to True."""
+        assert get_rls_context_active() is False
+        with admin_context():
+            assert get_rls_context_active() is True
+        assert get_rls_context_active() is False
+
+    def test_nested_contexts_restore_active_flag(self, db, tenant_a, tenant_b):
+        """Nested contexts properly restore the active flag."""
+        assert get_rls_context_active() is False
+        with tenant_context(tenant_a.pk):
+            assert get_rls_context_active() is True
+            with admin_context():
+                assert get_rls_context_active() is True
+            assert get_rls_context_active() is True
+        assert get_rls_context_active() is False
+
+    def test_active_flag_restored_on_exception(self, db, tenant_a):
+        """_rls_context_active is restored when an exception occurs."""
+        assert get_rls_context_active() is False
+        with pytest.raises(RuntimeError, match="boom"), tenant_context(tenant_a.pk):
+            raise RuntimeError("boom")
+        assert get_rls_context_active() is False
+
+    def test_middleware_sets_and_clears_active(self, db, tenant_a_user):
+        """Middleware sets active on request and clears on response."""
+        assert get_rls_context_active() is False
+        mw = RLSTenantMiddleware(get_response=lambda r: MagicMock())
+        request = MagicMock()
+        request.user = tenant_a_user
+        mw.process_request(request)
+        assert get_rls_context_active() is True
+        mw.process_response(request, MagicMock())
+        assert get_rls_context_active() is False
+
+    def test_middleware_clears_active_on_exception(self, db, tenant_a_user):
+        """Middleware clears active flag via process_exception."""
+        assert get_rls_context_active() is False
+        mw = RLSTenantMiddleware(get_response=lambda r: MagicMock())
+        request = MagicMock()
+        request.user = tenant_a_user
+        mw.process_request(request)
+        assert get_rls_context_active() is True
+        mw.process_exception(request, RuntimeError("view error"))
+        assert get_rls_context_active() is False

--- a/tests/test_tenants/test_state.py
+++ b/tests/test_tenants/test_state.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 from django_rls_tenants.tenants.state import (
     get_current_tenant_id,
+    get_rls_context_active,
     reset_current_tenant_id,
+    reset_rls_context_active,
     set_current_tenant_id,
+    set_rls_context_active,
 )
 
 
@@ -107,3 +110,58 @@ class TestTenantIdTypes:
         token = set_current_tenant_id("42")
         assert get_current_tenant_id() == "42"
         reset_current_tenant_id(token)
+
+
+class TestGetRlsContextActive:
+    """Tests for get_rls_context_active()."""
+
+    def test_default_is_false(self):
+        """Returns False when no RLS context is active."""
+        assert get_rls_context_active() is False
+
+    def test_returns_set_value(self):
+        """Returns the value set by set_rls_context_active()."""
+        token = set_rls_context_active(True)
+        assert get_rls_context_active() is True
+        reset_rls_context_active(token)
+
+
+class TestRlsContextActiveSetAndReset:
+    """Tests for set_rls_context_active() and reset_rls_context_active()."""
+
+    def test_set_true_and_reset(self):
+        """Set active to True and reset restores False."""
+        token = set_rls_context_active(True)
+        assert get_rls_context_active() is True
+        reset_rls_context_active(token)
+        assert get_rls_context_active() is False
+
+    def test_nested_set_and_reset(self):
+        """Nested set/reset restores the outer value."""
+        token_outer = set_rls_context_active(True)
+        token_inner = set_rls_context_active(False)
+        assert get_rls_context_active() is False
+        reset_rls_context_active(token_inner)
+        assert get_rls_context_active() is True
+        reset_rls_context_active(token_outer)
+        assert get_rls_context_active() is False
+
+    def test_three_level_nesting(self):
+        """Three levels of nesting restore correctly."""
+        token_1 = set_rls_context_active(True)
+        assert get_rls_context_active() is True
+
+        token_2 = set_rls_context_active(False)
+        assert get_rls_context_active() is False
+
+        token_3 = set_rls_context_active(True)
+        assert get_rls_context_active() is True
+
+        reset_rls_context_active(token_3)
+        assert get_rls_context_active() is False
+
+        reset_rls_context_active(token_2)
+        assert get_rls_context_active() is True
+
+        reset_rls_context_active(token_1)
+        assert get_rls_context_active() is False


### PR DESCRIPTION
This pull request introduces a new "strict mode" for tenant-aware query enforcement, along with supporting infrastructure and documentation. When enabled, strict mode ensures that any database query on RLS-protected models without an active tenant or admin context (via context managers, middleware, or `for_user()`) will raise a clear exception, helping prevent accidental data leaks or unsafe queries. The implementation uses a new context variable to track the presence of tenant context and integrates this check into key query evaluation methods and middleware. Documentation and configuration have been updated accordingly.

**Strict Mode Feature and Enforcement:**

* Added a new `STRICT_MODE` configuration option (default: `False`). When enabled, all key `TenantQuerySet` evaluation methods (e.g., `count()`, `get()`, `update()`, `delete()`, `first()`, `last()`, `bulk_create()`, `bulk_update()`, `iterator()`, and iteration) will raise `NoTenantContextError` if no RLS context is active. This prevents queries on RLS-protected models outside of a tenant or admin context. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR12-R21) [[2]](diffhunk://#diff-9acc7e235e9a850a18883c7882b77816b608673af80b5435ed2eb2e77c475effR230-R347) [[3]](diffhunk://#diff-9acc7e235e9a850a18883c7882b77816b608673af80b5435ed2eb2e77c475effR358) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R43-R44) [[5]](diffhunk://#diff-5eebef5003930a17826e073530791b81efaa6c658cc09fbeb126152f95da3c25R21) [[6]](diffhunk://#diff-5eebef5003930a17826e073530791b81efaa6c658cc09fbeb126152f95da3c25R40) [[7]](diffhunk://#diff-5eebef5003930a17826e073530791b81efaa6c658cc09fbeb126152f95da3c25R88-R98)

* Introduced a new `_rls_context_active` `ContextVar` with public accessors (`get_rls_context_active`, `set_rls_context_active`, `reset_rls_context_active`) to track whether a valid RLS context is active. This allows strict mode to distinguish between "no context" and "admin context". [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR12-R21) [[2]](diffhunk://#diff-9fd659aa53e079b3712dbf5d2c2ac6145723cd110adb9df198d6e65441f9dd1cR27-R31) [[3]](diffhunk://#diff-9fd659aa53e079b3712dbf5d2c2ac6145723cd110adb9df198d6e65441f9dd1cR48-R52) [[4]](diffhunk://#diff-cedf9ff0a20ca7f6426cdfc2351c9979d559b67ba0a9358c407df40ab55b0e8dR29-R33) [[5]](diffhunk://#diff-cedf9ff0a20ca7f6426cdfc2351c9979d559b67ba0a9358c407df40ab55b0e8dR49-R55)

**Context Management and Middleware Integration:**

* Updated `tenant_context()`, `admin_context()`, `RLSTenantMiddleware`, and `for_user()` to set `_rls_context_active=True` on entry and restore the previous value on exit, ensuring the strict mode guard works correctly across all entry points. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR36-R38) [[2]](diffhunk://#diff-ef7641bce825447cf725747e5d04c0ec13eb2859a207aacf6350bedf5252b154L19-R24) [[3]](diffhunk://#diff-ef7641bce825447cf725747e5d04c0ec13eb2859a207aacf6350bedf5252b154R105) [[4]](diffhunk://#diff-ef7641bce825447cf725747e5d04c0ec13eb2859a207aacf6350bedf5252b154R118) [[5]](diffhunk://#diff-ef7641bce825447cf725747e5d04c0ec13eb2859a207aacf6350bedf5252b154R144) [[6]](diffhunk://#diff-ef7641bce825447cf725747e5d04c0ec13eb2859a207aacf6350bedf5252b154R155) [[7]](diffhunk://#diff-185802f206895359f691fa62a7393d4699a7ca708ed67af2e07aded93bbc4e36L18-R23) [[8]](diffhunk://#diff-185802f206895359f691fa62a7393d4699a7ca708ed67af2e07aded93bbc4e36R102-R106) [[9]](diffhunk://#diff-185802f206895359f691fa62a7393d4699a7ca708ed67af2e07aded93bbc4e36L106-R138) [[10]](diffhunk://#diff-185802f206895359f691fa62a7393d4699a7ca708ed67af2e07aded93bbc4e36L176-R201) [[11]](diffhunk://#diff-185802f206895359f691fa62a7393d4699a7ca708ed67af2e07aded93bbc4e36R217-R223)

**Documentation and Configuration:**

* Updated documentation in `README.md` and `AGENTS.md` to describe the new `STRICT_MODE` option, its behavior, and usage instructions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R43-R44) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R77-R87)
* Updated `CHANGELOG.md` to reflect the addition of strict mode and related changes. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR12-R21) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR36-R38)

These changes significantly improve the safety and predictability of multi-tenant applications by making it much harder to accidentally run unsafe queries outside a valid tenant or admin context.