### PR TITLE
feat: add __repr__ to RLSConstraint, RLSM2MConstraint, and RLSTenantsConfig

### DIFF
--- a/django_rls_tenants/rls/constraints.py
+++ b/django_rls_tenants/rls/constraints.py
@@ -224,6 +224,18 @@ class RLSConstraint(BaseConstraint):
     ) -> None:
         """No-op: RLS is enforced at the database level, not in Django validation."""
 
+    def __repr__(self) -> str:
+        parts = [f"name={self.name!r}", f"field={self.field!r}"]
+        if self.guc_tenant_var != "rls.current_tenant":
+            parts.append(f"guc_tenant_var={self.guc_tenant_var!r}")
+        if self.guc_admin_var != "rls.is_admin":
+            parts.append(f"guc_admin_var={self.guc_admin_var!r}")
+        if self.tenant_pk_type != "int":
+            parts.append(f"tenant_pk_type={self.tenant_pk_type!r}")
+        if self.extra_bypass_flags:
+            parts.append(f"extra_bypass_flags={self.extra_bypass_flags!r}")
+        return f"RLSConstraint({', '.join(parts)})"
+
     def __eq__(self, other: object) -> bool:
         if isinstance(other, RLSConstraint):
             return (
@@ -511,6 +523,26 @@ class RLSM2MConstraint(BaseConstraint):
         using: str | None = None,
     ) -> None:
         """No-op: RLS is enforced at the database level, not in Django validation."""
+
+    def __repr__(self) -> str:
+        parts = [
+            f"name={self.name!r}",
+            f"from_model={self.from_model!r}",
+            f"to_model={self.to_model!r}",
+            f"from_fk={self.from_fk!r}",
+            f"to_fk={self.to_fk!r}",
+        ]
+        if self.from_tenant_fk != "tenant":
+            parts.append(f"from_tenant_fk={self.from_tenant_fk!r}")
+        if self.to_tenant_fk != "tenant":
+            parts.append(f"to_tenant_fk={self.to_tenant_fk!r}")
+        if self.guc_tenant_var != "rls.current_tenant":
+            parts.append(f"guc_tenant_var={self.guc_tenant_var!r}")
+        if self.guc_admin_var != "rls.is_admin":
+            parts.append(f"guc_admin_var={self.guc_admin_var!r}")
+        if self.tenant_pk_type != "int":
+            parts.append(f"tenant_pk_type={self.tenant_pk_type!r}")
+        return f"RLSM2MConstraint({', '.join(parts)})"
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, RLSM2MConstraint):

--- a/django_rls_tenants/tenants/conf.py
+++ b/django_rls_tenants/tenants/conf.py
@@ -109,6 +109,13 @@ class RLSTenantsConfig:
         """
         return self._get("DATABASES", ["default"])  # type: ignore[no-any-return]
 
+    def __repr__(self) -> str:
+        try:
+            model = self.TENANT_MODEL
+        except Exception:
+            model = "<unset>"
+        return f"RLSTenantsConfig(TENANT_MODEL={model!r})"
+
     def __init__(self) -> None:
         self._config_cache: dict[str, Any] | None = None
         self._unknown_keys_checked: bool = False


### PR DESCRIPTION
Closes #23

## What

Added `__repr__()` methods to all three public classes:

- `RLSConstraint` — shows `name`, `field`, and any non-default GUC/type args
- `RLSM2MConstraint` — shows `name`, both model paths, both FK columns, and any non-default args
- `RLSTenantsConfig` — shows `TENANT_MODEL` (the most useful identifier)

## Why

Previously these showed as `<RLSConstraint object at 0x7f...>` which is useless when debugging migration errors or inspecting objects in the Django shell. The new output looks like:

```python
>>> constraint
RLSConstraint(name='rls_policy_mymodel', field='tenant')

>>> m2m
RLSM2MConstraint(name='rls_m2m_projects_tags', from_model='myapp.Project', to_model='myapp.Tag', from_fk='project_id', to_fk='tag_id')

>>> rls_tenants_config
RLSTenantsConfig(TENANT_MODEL='myapp.Tenant')
```

Only non-default attribute values are shown to keep output concise.