### PR TITLE
docs: add module docstrings, SQL safety comments, type:ignore explanations

### DIFF
--- a/django_rls_tenants/management/__init__.py
+++ b/django_rls_tenants/management/__init__.py
@@ -1,0 +1,10 @@
+"""Django management commands package for django-rls-tenants.
+
+Provides CLI tools for verifying and applying Row-Level Security (RLS)
+policies on protected tables:
+
+- ``check_rls``: Verify that RLS policies are enabled and correctly
+  configured on all ``RLSProtectedModel`` subclasses and M2M through tables.
+- ``setup_m2m_rls``: Apply RLS policies retroactively to M2M through
+  tables on existing deployments without re-running migrations.
+"""

--- a/django_rls_tenants/management/commands/__init__.py
+++ b/django_rls_tenants/management/commands/__init__.py
@@ -1,0 +1,6 @@
+"""Individual management command modules for django-rls-tenants.
+
+Each module in this package implements a single Django management command.
+See the parent ``management`` package docstring for an overview of available
+commands.
+"""

--- a/django_rls_tenants/management/commands/check_rls.py
+++ b/django_rls_tenants/management/commands/check_rls.py
@@ -156,6 +156,9 @@ class Command(BaseCommand):
         conn = connections[db_alias]
         with conn.cursor() as cursor:
             placeholders = ", ".join(["%s"] * len(tables))
+            # Safety: ``placeholders`` contains only literal ``%s`` tokens —
+            # no user data is interpolated into the SQL string. Table names
+            # are passed as parameterised values, preventing SQL injection.
             cursor.execute(
                 f"SELECT relname, relrowsecurity, relforcerowsecurity "
                 f"FROM pg_class WHERE relname IN ({placeholders})",
@@ -185,6 +188,9 @@ class Command(BaseCommand):
         conn = connections[db_alias]
         with conn.cursor() as cursor:
             placeholders = ", ".join(["%s"] * len(tables))
+            # Safety: ``placeholders`` contains only literal ``%s`` tokens —
+            # no user data is interpolated into the SQL string. Table names
+            # are passed as parameterised values, preventing SQL injection.
             cursor.execute(
                 f"SELECT tablename, policyname "
                 f"FROM pg_policies WHERE tablename IN ({placeholders})",

--- a/django_rls_tenants/tenants/managers.py
+++ b/django_rls_tenants/tenants/managers.py
@@ -94,7 +94,7 @@ def _rls_model_cache() -> frozenset[type[models.Model]]:
     return frozenset(protected)
 
 
-class TenantQuerySet(models.QuerySet):  # type: ignore[type-arg]
+class TenantQuerySet(models.QuerySet):  # type: ignore[type-arg]  -- Django's QuerySet is generic at runtime but unparameterised in django-stubs; suppressed to avoid false positives.
     """QuerySet that sets RLS GUC variables at evaluation time.
 
     Stores the user reference from ``for_user()`` and defers GUC setup
@@ -223,7 +223,7 @@ class TenantQuerySet(models.QuerySet):  # type: ignore[type-arg]
 
     def _clone(self) -> TenantQuerySet:
         """Propagate ``_rls_user`` to cloned querysets."""
-        clone: TenantQuerySet = super()._clone()  # type: ignore[misc]
+        clone: TenantQuerySet = super()._clone()  # type: ignore[misc]  -- _clone() is an internal Django API not typed in django-stubs; return type is QuerySet, not TenantQuerySet.
         clone._rls_user = self._rls_user
         return clone
 
@@ -412,7 +412,7 @@ def _resolve_related_model(
     return current
 
 
-class RLSManager(models.Manager):  # type: ignore[type-arg]
+class RLSManager(models.Manager):  # type: ignore[type-arg]  -- Same as TenantQuerySet: Manager is generic at runtime but unparameterised in django-stubs.
     """Manager for RLS-protected models.
 
     Provides ``for_user()`` for scoped queries and

--- a/django_rls_tenants/tenants/managers.py
+++ b/django_rls_tenants/tenants/managers.py
@@ -95,7 +95,8 @@ def _rls_model_cache() -> frozenset[type[models.Model]]:
     return frozenset(protected)
 
 
-# Type ignore explanation: Django's QuerySet is generic at runtime but unparameterised in django-stubs; suppressed to avoid false positives.
+# Type ignore explanation: Django's QuerySet is generic at runtime but
+# unparameterised in django-stubs; suppressed to avoid false positives.
 class TenantQuerySet(models.QuerySet):  # type: ignore[type-arg]
     """QuerySet that sets RLS GUC variables at evaluation time.
 
@@ -225,7 +226,8 @@ class TenantQuerySet(models.QuerySet):  # type: ignore[type-arg]
 
     def _clone(self) -> TenantQuerySet:
         """Propagate ``_rls_user`` to cloned querysets."""
-        # Type ignore explanation: _clone() is an internal Django API not typed in django-stubs; return type is QuerySet, not TenantQuerySet.
+        # Type ignore explanation: _clone() is an internal Django API not typed in
+        # django-stubs; return type is QuerySet, not TenantQuerySet.
         clone: TenantQuerySet = super()._clone()  # type: ignore[misc]
         clone._rls_user = self._rls_user
         return clone
@@ -415,7 +417,8 @@ def _resolve_related_model(
     return current
 
 
-# Type ignore explanation: Same as TenantQuerySet: Manager is generic at runtime but unparameterised in django-stubs.
+# Type ignore explanation: Same as TenantQuerySet: Manager is generic at runtime
+# but unparameterised in django-stubs.
 class RLSManager(models.Manager):  # type: ignore[type-arg]
     """Manager for RLS-protected models.
 

--- a/django_rls_tenants/tenants/managers.py
+++ b/django_rls_tenants/tenants/managers.py
@@ -75,7 +75,8 @@ def _rls_model_cache() -> frozenset[type[models.Model]]:
         RuntimeError: If called before ``django.apps`` is fully ready,
             to prevent caching an incomplete model set.
     """
-    from django.apps import apps  # noqa: PLC0415  -- lazy import avoids circular
+    # Lazy import avoids a circular import.
+    from django.apps import apps  # noqa: PLC0415
 
     from django_rls_tenants.rls.constraints import RLSConstraint  # noqa: PLC0415
 
@@ -94,7 +95,8 @@ def _rls_model_cache() -> frozenset[type[models.Model]]:
     return frozenset(protected)
 
 
-class TenantQuerySet(models.QuerySet):  # type: ignore[type-arg]  -- Django's QuerySet is generic at runtime but unparameterised in django-stubs; suppressed to avoid false positives.
+# Type ignore explanation: Django's QuerySet is generic at runtime but unparameterised in django-stubs; suppressed to avoid false positives.
+class TenantQuerySet(models.QuerySet):  # type: ignore[type-arg]
     """QuerySet that sets RLS GUC variables at evaluation time.
 
     Stores the user reference from ``for_user()`` and defers GUC setup
@@ -223,7 +225,8 @@ class TenantQuerySet(models.QuerySet):  # type: ignore[type-arg]  -- Django's Qu
 
     def _clone(self) -> TenantQuerySet:
         """Propagate ``_rls_user`` to cloned querysets."""
-        clone: TenantQuerySet = super()._clone()  # type: ignore[misc]  -- _clone() is an internal Django API not typed in django-stubs; return type is QuerySet, not TenantQuerySet.
+        # Type ignore explanation: _clone() is an internal Django API not typed in django-stubs; return type is QuerySet, not TenantQuerySet.
+        clone: TenantQuerySet = super()._clone()  # type: ignore[misc]
         clone._rls_user = self._rls_user
         return clone
 
@@ -412,7 +415,8 @@ def _resolve_related_model(
     return current
 
 
-class RLSManager(models.Manager):  # type: ignore[type-arg]  -- Same as TenantQuerySet: Manager is generic at runtime but unparameterised in django-stubs.
+# Type ignore explanation: Same as TenantQuerySet: Manager is generic at runtime but unparameterised in django-stubs.
+class RLSManager(models.Manager):  # type: ignore[type-arg]
     """Manager for RLS-protected models.
 
     Provides ``for_user()`` for scoped queries and
@@ -441,7 +445,8 @@ class RLSManager(models.Manager):  # type: ignore[type-arg]  -- Same as TenantQu
     def prepare_tenant_in_model_data(
         self,
         model_data: dict[str, Any],
-        as_user: TenantUser,  # noqa: ARG002  -- part of public API
+        # Unused but part of the public API contract.
+        as_user: TenantUser,  # noqa: ARG002
     ) -> None:
         """Resolve a raw tenant ID for model creation.
 
@@ -454,7 +459,8 @@ class RLSManager(models.Manager):  # type: ignore[type-arg]  -- Same as TenantQu
             model_data: Dict of field names to values.
             as_user: User for context (unused here but part of API).
         """
-        from django.apps import apps  # noqa: PLC0415  -- lazy import avoids circular
+        # Lazy import avoids a circular import.
+        from django.apps import apps  # noqa: PLC0415
 
         conf = rls_tenants_config
         field_name = conf.TENANT_FK_FIELD


### PR DESCRIPTION
Fixes #22

## What was changed

**management package  files** — both were empty (0 bytes). Added module docstrings describing the purpose of the package and the two management commands it contains.

**SQL safety comments in `check_rls.py`** — Added a comment above each f-string SQL block in `_check_rls_status()` and `_check_policies()` clarifying that:
- only literal `%s` tokens are string-interpolated
- all user-controlled values (table names) are passed as parameterised query values, preventing SQL injection

**`type: ignore` explanations in `managers.py`** — Expanded the three bare `# type: ignore[...]` comments with inline explanations:
- `TenantQuerySet(models.QuerySet)` and `RLSManager(models.Manager)`: Django's generics are not parameterised in django-stubs, causing false-positive `type-arg` errors
- `super()._clone()`: `_clone()` is an internal Django API not typed in django-stubs; return type is `QuerySet`, not `TenantQuerySet`

No functional changes — pure documentation and comment improvements.