### PR TITLE
Fix documentation inaccuracies in CHANGELOG, SECURITY.md, README and docs (#21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   This guides users toward the safe context manager APIs (`tenant_context`,
   `admin_context`) instead of direct state manipulation.
 
+### Fixed
+
+- **Documentation accuracy pass** (#21): corrected inaccuracies across
+  CHANGELOG, SECURITY.md, README.md, and docs/ pages.
+  - SECURITY.md: updated supported versions table to include 1.1.x and 1.2.x.
+  - CHANGELOG.md: fixed strict mode PR references from #13 to #14. Corrected
+    claim that `for_user()` sets `_rls_context_active` (it satisfies strict
+    mode via `_rls_user` instead).
+  - README.md: simplified Quick Start config to show only the required
+    `TENANT_MODEL` key instead of listing all defaults (which were incomplete).
+  - docs/why-rls.md: replaced incorrect `COALESCE`-based policy example with
+    the actual `CASE WHEN` / `nullif()` pattern used by `RLSConstraint`. Fixed
+    GUC-setting description to distinguish `set_config()` from `SET LOCAL`.
+
 ## [1.2.0] - 2026-03-21
 
 ### Added
@@ -45,12 +59,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   methods (`count()`, `exists()`, `aggregate()`, `update()`, `delete()`,
   `iterator()`, `bulk_create()`, `bulk_update()`, `get()`, `first()`, `last()`,
   and iteration via `_fetch_all()`) raise `NoTenantContextError` if no RLS
-  context is active. Off by default. (#13)
+  context is active. Off by default. (#14)
 - `_rls_context_active` ContextVar in `state.py` with public accessors
   `get_rls_context_active()`, `set_rls_context_active()`, and
   `reset_rls_context_active()`. Tracks whether any RLS context (tenant or admin)
   is active, enabling strict mode to distinguish "no context" from "admin
-  context". (#13)
+  context". (#14)
 - Custom exception hierarchy in `django_rls_tenants.exceptions`: `RLSTenantError`
   (base), `NoTenantContextError`, `RLSConfigurationError`. All importable from
   the top-level `django_rls_tenants` package. (#12)
@@ -65,9 +79,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `tenant_context()`, `admin_context()`, `RLSTenantMiddleware`, and `for_user()`
-  now set `_rls_context_active=True` on entry and restore the previous value on
-  exit. This enables strict mode's "no context" detection. (#13)
+- `tenant_context()`, `admin_context()`, and `RLSTenantMiddleware` now set
+  `_rls_context_active=True` on entry and restore the previous value on exit.
+  This enables strict mode's "no context" detection. `for_user()` satisfies
+  strict mode via the stored `_rls_user` reference. (#14)
 - `tenant_context()` and `_resolve_user_guc_vars()` now raise
   `NoTenantContextError` instead of `ValueError` when a non-admin user has
   `rls_tenant_id=None` or when `tenant_id` is `None`.

--- a/README.md
+++ b/README.md
@@ -34,14 +34,7 @@ pip install django-rls-tenants
 INSTALLED_APPS = [..."django_rls_tenants"]
 
 RLS_TENANTS = {
-    "TENANT_MODEL": "myapp.Tenant",
-    "TENANT_FK_FIELD": "tenant",
-    "GUC_PREFIX": "rls",
-    "USER_PARAM_NAME": "as_user",
-    "TENANT_PK_TYPE": "int",
-    "USE_LOCAL_SET": False,
-    "DATABASES": ["default"],
-    "STRICT_MODE": False,
+    "TENANT_MODEL": "myapp.Tenant",  # required
 }
 
 MIDDLEWARE = [..."django_rls_tenants.RLSTenantMiddleware"]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,8 @@
 
 | Version | Supported          |
 |---------|--------------------|
+| 1.2.x   | :white_check_mark: |
+| 1.1.x   | :white_check_mark: |
 | 1.0.x   | :white_check_mark: |
 | < 1.0   | :x:                |
 

--- a/docs/why-rls.md
+++ b/docs/why-rls.md
@@ -56,25 +56,35 @@ where `tenant_id` matches the current session variable."
 The SQL behind this is straightforward:
 
 ```sql
-CREATE POLICY rls_policy ON orders
-    USING (tenant_id = COALESCE(
-        NULLIF(current_setting('rls.current_tenant', true), ''),
-        ''
-    )::integer);
+CREATE POLICY "orders_tenant_isolation_policy" ON "orders"
+    USING (
+        CASE WHEN current_setting('rls.is_admin', true) = 'true'
+             THEN true
+             ELSE tenant_id = nullif(
+                 current_setting('rls.current_tenant', true), '')::int
+        END
+    )
+    WITH CHECK (
+        CASE WHEN current_setting('rls.is_admin', true) = 'true'
+             THEN true
+             ELSE tenant_id = nullif(
+                 current_setting('rls.current_tenant', true), '')::int
+        END
+    );
 ```
 
 Key properties:
 
 - **Every query is filtered** — ORM, raw SQL, `cursor.execute()`, `dbshell`.
-- **INSERT and UPDATE are checked** — you cannot write a row for a tenant you
-  do not belong to.
+- **INSERT and UPDATE are checked** — the `WITH CHECK` clause validates writes.
 - **FORCE ROW LEVEL SECURITY** — even the table owner is subject to the policy.
 
 ## The "Missing Context = Zero Rows" Guarantee
 
-The most important safety property: if the session variable is not set, the
-`COALESCE` expression evaluates to an empty string. An empty string does not
-match any `tenant_id`, so the query returns **zero rows**.
+The most important safety property: if the session variable is not set,
+`current_setting('rls.current_tenant', true)` returns an empty string, and
+`nullif('', '')` converts it to `NULL`. Since `tenant_id = NULL` is always
+false, the query returns **zero rows**.
 
 This is fail-closed by design:
 
@@ -90,7 +100,8 @@ enforces the boundary.
 1. **Middleware** reads `request.user` and extracts tenant identity via the
    `TenantUser` protocol.
 2. **GUC variables** (`rls.current_tenant`, `rls.is_admin`) are set on the
-   PostgreSQL connection using `SET` or `SET LOCAL`.
+   PostgreSQL connection using `set_config()` (session-scoped) or `SET LOCAL`
+   (transaction-scoped, when `USE_LOCAL_SET=True`).
 3. **RLS policies** are generated automatically when you run Django migrations
    — no hand-written SQL required.
 4. **Context managers** (`tenant_context`, `admin_context`) handle non-request


### PR DESCRIPTION
This pull request focuses on correcting and improving project documentation for accuracy and clarity. The changes address outdated or incorrect information in several documentation files, update configuration examples, and clarify technical details in policy examples and descriptions.

**Documentation accuracy and clarity improvements:**

* General documentation:
  - Corrected inaccuracies in `CHANGELOG.md`, `SECURITY.md`, `README.md`, and `docs/why-rls.md` to ensure information is up to date and accurate.
  - Updated `SECURITY.md` to reflect support for versions 1.1.x and 1.2.x.

* CHANGELOG and strict mode references:
  - Fixed strict mode pull request references from `#13` to `#14` and clarified how `for_user()` satisfies strict mode by storing `_rls_user` instead of setting `_rls_context_active`. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL48-R67) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL68-R85)

* Configuration examples:
  - Simplified the Quick Start configuration in `README.md` to show only the required `TENANT_MODEL` key, removing incomplete defaults.

* Policy and technical documentation:
  - Replaced an incorrect `COALESCE`-based example in `docs/why-rls.md` with the actual `CASE WHEN`/`nullif()` pattern used by `RLSConstraint`, and clarified how session variables affect policy enforcement.
  - Updated the description of GUC variable setting to distinguish between `set_config()` and `SET LOCAL` usage.