### PR TITLE
feat: add setup_m2m_rls --verbose flag (#28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.2] - Unreleased
+
+### Added
+
+- **`setup_m2m_rls --verbose`** (#28): print each M2M through-table policy's
+  `CREATE POLICY` SQL before applying it, so DBAs and security reviewers can
+  audit the exact SQL while still applying it in one run. Combine with
+  `--dry-run` to print without executing.
+
 ## [1.2.1] - 2026-06-27
 
 ### Added

--- a/django_rls_tenants/management/commands/setup_m2m_rls.py
+++ b/django_rls_tenants/management/commands/setup_m2m_rls.py
@@ -37,11 +37,18 @@ class Command(BaseCommand):
             default=False,
             help="Print the SQL that would be executed without applying it.",
         )
+        parser.add_argument(
+            "--verbose",
+            action="store_true",
+            default=False,
+            help="Print each policy's SQL before applying it.",
+        )
 
     def handle(self, *args: Any, **options: Any) -> None:  # noqa: ARG002
         """Discover and apply M2M RLS policies."""
         db_alias: str = options["database"]
         dry_run: bool = options["dry_run"]
+        verbose: bool = options["verbose"]
 
         m2m_info = _collect_m2m_tables()
         if not m2m_info:
@@ -91,10 +98,10 @@ class Command(BaseCommand):
                 table=table, admin_check=admin_check, subquery_clause=subquery_clause
             )
 
-            if dry_run:
+            if verbose or dry_run:
                 self.stdout.write(f"\n-- {info['description']} ({table}):")
                 self.stdout.write(sql)
-            else:
+            if not dry_run:
                 with conn.cursor() as cursor:
                     cursor.execute(sql)
                 self.stdout.write(

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -71,7 +71,7 @@ Better CLI tooling and earlier misconfiguration detection.
   *Why:* CI/CD pipelines need clean output — success should be silent.
   (shipped in v1.2.1)
 
-- [ ] **`setup_m2m_rls --verbose`** — Show the generated SQL before execution.
+- [x] **`setup_m2m_rls --verbose`** — Show the generated SQL before execution.
   *Why:* DBAs and security reviewers need to audit what SQL will run before
   approving it.
 

--- a/docs/guides/management-commands.md
+++ b/docs/guides/management-commands.md
@@ -98,6 +98,7 @@ that need to add M2M RLS coverage without re-running migrations.
 ```bash
 python manage.py setup_m2m_rls              # apply policies
 python manage.py setup_m2m_rls --dry-run    # preview SQL without executing
+python manage.py setup_m2m_rls --verbose    # print each policy's SQL, then apply it
 python manage.py setup_m2m_rls --database replica
 ```
 
@@ -114,6 +115,7 @@ python manage.py setup_m2m_rls --database replica
 |------|---------|-------------|
 | `--database` | `default` | Database alias to apply policies on |
 | `--dry-run` | off | Print SQL without executing |
+| `--verbose` | off | Print each policy's SQL before applying it |
 
 ### When to Use
 
@@ -125,6 +127,20 @@ python manage.py setup_m2m_rls --database replica
 !!! tip
     For new M2M fields, prefer using `AddM2MRLSPolicy` in a migration instead.
     `setup_m2m_rls` is a convenience for retroactive application.
+
+### Verbose Mode
+
+`--verbose` prints the same `CREATE POLICY` SQL that `--dry-run` shows, but then still
+applies each policy — useful for DBAs and security reviewers who want to audit the SQL
+while applying it in one run. Passing both `--verbose` and `--dry-run` is equivalent to
+`--dry-run`: the SQL is printed once and nothing is executed.
+
+```
+-- Project.members (auto M2M) (test_project_members):
+CREATE POLICY ...
+
+Project.members (auto M2M) (test_project_members): policy applied
+```
 
 ## Using RLS in Custom Management Commands
 

--- a/tests/test_integration/test_setup_m2m_rls.py
+++ b/tests/test_integration/test_setup_m2m_rls.py
@@ -6,8 +6,33 @@ from io import StringIO
 
 import pytest
 from django.core.management import call_command
+from django.db import connection
+
+from django_rls_tenants.management.commands.check_rls import _collect_m2m_tables
+from django_rls_tenants.rls.constraints import _build_m2m_drop_sql
 
 pytestmark = pytest.mark.django_db
+
+
+def _unprotect_one_m2m_table() -> str:
+    """Drop the RLS policy on one discovered M2M table and return its name.
+
+    Integration tests run under ``SET ROLE`` (the autouse ``enforce_rls``
+    fixture switches to a non-superuser), but dropping and re-creating
+    policies needs table ownership, so we ``RESET ROLE`` back to the
+    superuser login role first. Every change here is DDL inside the test's
+    transaction, so it is rolled back automatically once the test finishes.
+
+    Leaving the table unprotected forces ``setup_m2m_rls`` to actually apply
+    a policy -- otherwise every M2M table is already protected and the
+    command only ever reports "skipping", never exercising the apply path
+    that ``--verbose`` annotates.
+    """
+    table = next(iter(_collect_m2m_tables()))
+    with connection.cursor() as cursor:
+        cursor.execute("RESET ROLE")
+        cursor.execute(_build_m2m_drop_sql(table=table))
+    return table
 
 
 class TestSetupM2MRlsCommand:
@@ -34,3 +59,28 @@ class TestSetupM2MRlsCommand:
         output = out.getvalue()
         # All M2M tables from the migration should already have policies
         assert "policy applied" not in output.lower() or "skipping" in output.lower()
+
+    def test_verbose_prints_sql_and_applies(self):
+        """--verbose prints each policy's SQL and still applies it."""
+        table = _unprotect_one_m2m_table()
+
+        out = StringIO()
+        call_command("setup_m2m_rls", "--verbose", stdout=out)
+        output = out.getvalue()
+
+        # SQL is printed before execution...
+        assert "CREATE POLICY" in output
+        assert f"{table}_m2m_rls_policy" in output
+        # ...and the policy is actually applied (unlike --dry-run).
+        assert "policy applied" in output
+
+    def test_non_verbose_does_not_print_sql(self):
+        """Without --verbose the policy is applied but the SQL is not printed."""
+        _unprotect_one_m2m_table()
+
+        out = StringIO()
+        call_command("setup_m2m_rls", stdout=out)
+        output = out.getvalue()
+
+        assert "policy applied" in output
+        assert "CREATE POLICY" not in output

--- a/tests/test_integration/test_setup_m2m_rls.py
+++ b/tests/test_integration/test_setup_m2m_rls.py
@@ -35,6 +35,22 @@ def _unprotect_one_m2m_table() -> str:
     return table
 
 
+def _m2m_policy_exists(table: str) -> bool:
+    """Return whether the M2M RLS policy exists on ``table``.
+
+    Queries ``pg_policies`` directly so tests can assert on the real database
+    state -- e.g. that ``--dry-run`` did *not* create the policy -- instead of
+    trusting the command's own stdout.
+    """
+    policy_name = f"{table}_m2m_rls_policy"
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "SELECT 1 FROM pg_policies WHERE tablename = %s AND policyname = %s",
+            [table, policy_name],
+        )
+        return cursor.fetchone() is not None
+
+
 class TestSetupM2MRlsCommand:
     """Tests for the setup_m2m_rls management command."""
 
@@ -63,6 +79,7 @@ class TestSetupM2MRlsCommand:
     def test_verbose_prints_sql_and_applies(self):
         """--verbose prints each policy's SQL and still applies it."""
         table = _unprotect_one_m2m_table()
+        assert not _m2m_policy_exists(table)  # precondition: dropped above
 
         out = StringIO()
         call_command("setup_m2m_rls", "--verbose", stdout=out)
@@ -73,10 +90,11 @@ class TestSetupM2MRlsCommand:
         assert f"{table}_m2m_rls_policy" in output
         # ...and the policy is actually applied (unlike --dry-run).
         assert "policy applied" in output
+        assert _m2m_policy_exists(table)
 
     def test_non_verbose_does_not_print_sql(self):
         """Without --verbose the policy is applied but the SQL is not printed."""
-        _unprotect_one_m2m_table()
+        table = _unprotect_one_m2m_table()
 
         out = StringIO()
         call_command("setup_m2m_rls", stdout=out)
@@ -84,3 +102,36 @@ class TestSetupM2MRlsCommand:
 
         assert "policy applied" in output
         assert "CREATE POLICY" not in output
+        assert _m2m_policy_exists(table)
+
+    def test_dry_run_does_not_apply_unprotected_table(self):
+        """--dry-run prints the SQL for an unprotected table but never applies it."""
+        table = _unprotect_one_m2m_table()
+        assert not _m2m_policy_exists(table)  # precondition: dropped above
+
+        out = StringIO()
+        call_command("setup_m2m_rls", "--dry-run", stdout=out)
+        output = out.getvalue()
+
+        # SQL is shown and counted as "would be updated"...
+        assert "CREATE POLICY" in output
+        assert f"{table}_m2m_rls_policy" in output
+        assert "would be updated" in output
+        # ...but nothing is executed: no success line and no policy in the catalog.
+        assert "policy applied" not in output
+        assert not _m2m_policy_exists(table)
+
+    def test_verbose_dry_run_prints_once_without_applying(self):
+        """--verbose --dry-run prints the SQL exactly once and applies nothing."""
+        table = _unprotect_one_m2m_table()
+
+        out = StringIO()
+        call_command("setup_m2m_rls", "--verbose", "--dry-run", stdout=out)
+        output = out.getvalue()
+
+        # dry-run wins: the SQL is printed a single time (the verbose and
+        # dry-run branches share one block, so it is not duplicated)...
+        assert output.count("CREATE POLICY") == 1
+        # ...and the policy is never created.
+        assert "policy applied" not in output
+        assert not _m2m_policy_exists(table)


### PR DESCRIPTION
## Summary

Adds the `setup_m2m_rls --verbose` flag (#28): print each M2M through-table
policy's `CREATE POLICY` SQL **before** applying it, so DBAs and security
reviewers can audit the exact SQL while still applying it in a single run.
Passing both `--verbose` and `--dry-run` behaves like `--dry-run` — the SQL is
printed once and nothing is executed.

This branch also includes a deep review pass over the three #28 commits.

## Review findings & fixes

The feature code (`verbose or dry_run` to print, `not dry_run` to execute) is
correct for all four flag combinations. The **tests** had a gap:

- The original `--verbose` tests asserted only on stdout text and never
  exercised the dry-run *"print but do not execute"* path on an actually
  unprotected table — leaving branch `104->110` in `setup_m2m_rls` uncovered,
  and leaving the documented `--verbose --dry-run` behaviour untested.

Hardening added in this PR:

- New `_m2m_policy_exists()` helper asserts on real `pg_policies` state instead
  of trusting the command's own output.
- `--dry-run` on an unprotected table: SQL is printed and counted as
  *"would be updated"*, but **no policy is created**.
- `--verbose --dry-run`: SQL is printed **exactly once** and nothing is applied.
- Existing `--verbose` / non-verbose apply tests now confirm the policy is
  actually created in the catalog (not just that stdout says so).

## Test plan

- `ruff check .` — passed
- `ruff format --check .` — passed (88 files)
- `mypy django_rls_tenants` — passed (strict, 23 files)
- `pytest` — **469 passed**, branch coverage **91.84%** (gate: 90%)
- `setup_m2m_rls.py` branch coverage gap (`104->110`) closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CqumNqavvCq27dN5ZWGBhh
