### PR TITLE
feat: add `check_rls --verbose` flag (#26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `CREATE POLICY` SQL before applying it, so DBAs and security reviewers can
   audit the exact SQL while still applying it in one run. Combine with
   `--dry-run` to print without executing.
+- **`check_rls --verbose`** (#26): print each policy's live `USING` /
+  `WITH CHECK` definition (read from the `pg_policy` catalog via
+  `pg_get_expr`) under the pass/fail line, for auditing and diagnosing
+  unexpected policy behaviour. `--quiet` takes precedence when both are given.
 
 ## [1.2.1] - 2026-06-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   audit the exact SQL while still applying it in one run. Combine with
   `--dry-run` to print without executing.
 - **`check_rls --verbose`** (#26): print each policy's live `USING` /
-  `WITH CHECK` definition (read from the `pg_policy` catalog via
-  `pg_get_expr`) under the pass/fail line, for auditing and diagnosing
-  unexpected policy behaviour. `--quiet` takes precedence when both are given.
+  `WITH CHECK` definition (read from the `pg_policies` view — the SQL
+  PostgreSQL actually enforces) under the pass/fail line, for auditing and
+  diagnosing unexpected policy behaviour. `--quiet` takes precedence when both
+  are given.
 
 ## [1.2.1] - 2026-06-27
 

--- a/django_rls_tenants/management/commands/check_rls.py
+++ b/django_rls_tenants/management/commands/check_rls.py
@@ -13,15 +13,6 @@ from typing import Any
 from django.core.management.base import BaseCommand
 from django.db import connections
 
-# Maps ``pg_policy.polcmd`` codes to the SQL command each policy applies to.
-_POLCMD_LABELS = {
-    "r": "SELECT",
-    "a": "INSERT",
-    "w": "UPDATE",
-    "d": "DELETE",
-    "*": "ALL",
-}
-
 
 def _collect_rls_tables() -> dict[str, str]:
     """Return ``{db_table: ModelName}`` for all concrete ``RLSProtectedModel`` subclasses."""
@@ -223,9 +214,10 @@ class Command(BaseCommand):
     ) -> None:
         """Batch-check RLS policies via ``pg_policies``.
 
-        With ``verbose`` (and not ``quiet``), additionally read each policy's
-        live ``USING`` / ``WITH CHECK`` expressions from the ``pg_policy``
-        catalog and print them indented under the policy-name line.
+        With ``verbose`` (and not ``quiet``), additionally print each policy's
+        live ``USING`` / ``WITH CHECK`` expressions indented under the
+        policy-name line, taken from the ``pg_policies`` view's ``qual`` /
+        ``with_check`` columns.
         """
         conn = connections[db_alias]
         with conn.cursor() as cursor:
@@ -233,51 +225,44 @@ class Command(BaseCommand):
             # Safety: ``placeholders`` contains only literal ``%s`` tokens —
             # no user data is interpolated into the SQL string. Table names
             # are passed as parameterised values, preventing SQL injection.
+            #
+            # ``cmd``/``qual``/``with_check`` come straight from ``pg_policies``:
+            # the view already decodes ``polcmd`` to its command word and runs
+            # ``pg_get_expr`` over the live policy nodes (the definition Postgres
+            # enforces), so verbose mode needs no extra catalog round-trip.
             cursor.execute(
-                f"SELECT tablename, policyname "
+                f"SELECT tablename, policyname, cmd, qual, with_check "
                 f"FROM pg_policies WHERE tablename IN ({placeholders})",
                 tables,
             )
-            policies_by_table: dict[str, list[str]] = {}
-            for row in cursor.fetchall():
-                policies_by_table.setdefault(row[0], []).append(row[1])
-
-            definitions_by_table: dict[str, list[tuple[str, str, str | None, str | None]]] = {}
-            if verbose and not quiet:
-                # ``pg_policies`` exposes only policy names; the ``pg_policy``
-                # catalog holds the live expressions, read back via
-                # ``pg_get_expr`` (the definition Postgres actually enforces).
-                # Same parameterised-table safety as the query above.
-                cursor.execute(
-                    f"SELECT c.relname, p.polname, p.polcmd, "
-                    f"pg_get_expr(p.polqual, p.polrelid), "
-                    f"pg_get_expr(p.polwithcheck, p.polrelid) "
-                    f"FROM pg_policy p JOIN pg_class c ON c.oid = p.polrelid "
-                    f"WHERE c.relname IN ({placeholders})",
-                    tables,
+            policies_by_table: dict[str, list[tuple[str, str, str | None, str | None]]] = {}
+            for tablename, policyname, cmd, qual, with_check in cursor.fetchall():
+                policies_by_table.setdefault(tablename, []).append(
+                    (policyname, cmd, qual, with_check)
                 )
-                for relname, polname, polcmd, using, with_check in cursor.fetchall():
-                    definitions_by_table.setdefault(relname, []).append(
-                        (polname, polcmd, using, with_check)
-                    )
 
         for table, model_name in table_to_model.items():
             policies = policies_by_table.get(table, [])
             if not policies:
                 errors.append(f"  {model_name} ({table}): no RLS policies found")
             elif not quiet:
-                self.stdout.write(f"  {model_name} ({table}): {', '.join(policies)}")
+                names = ", ".join(policy[0] for policy in policies)
+                self.stdout.write(f"  {model_name} ({table}): {names}")
                 if verbose:
-                    self._write_policy_details(definitions_by_table.get(table, []))
+                    self._write_policy_details(policies)
 
     def _write_policy_details(
         self,
-        definitions: list[tuple[str, str, str | None, str | None]],
+        policies: list[tuple[str, str, str | None, str | None]],
     ) -> None:
-        """Print the indented ``USING`` / ``WITH CHECK`` block for each policy."""
-        for polname, polcmd, using, with_check in definitions:
-            command = _POLCMD_LABELS.get(polcmd, polcmd)
-            self.stdout.write(f"    {polname} [{command}]")
+        """Print the indented ``USING`` / ``WITH CHECK`` block for each policy.
+
+        Each tuple is ``(policyname, cmd, using, with_check)`` straight from the
+        ``pg_policies`` view, where ``cmd`` is already the command word
+        (``ALL`` / ``SELECT`` / ...).
+        """
+        for polname, cmd, using, with_check in policies:
+            self.stdout.write(f"    {polname} [{cmd}]")
             self._write_clause("USING", using)
             self._write_clause("WITH CHECK", with_check)
 

--- a/django_rls_tenants/management/commands/check_rls.py
+++ b/django_rls_tenants/management/commands/check_rls.py
@@ -13,6 +13,15 @@ from typing import Any
 from django.core.management.base import BaseCommand
 from django.db import connections
 
+# Maps ``pg_policy.polcmd`` codes to the SQL command each policy applies to.
+_POLCMD_LABELS = {
+    "r": "SELECT",
+    "a": "INSERT",
+    "w": "UPDATE",
+    "d": "DELETE",
+    "*": "ALL",
+}
+
 
 def _collect_rls_tables() -> dict[str, str]:
     """Return ``{db_table: ModelName}`` for all concrete ``RLSProtectedModel`` subclasses."""
@@ -114,11 +123,18 @@ class Command(BaseCommand):
             default=False,
             help="Suppress success output; only show errors. Useful for CI/CD pipelines.",
         )
+        parser.add_argument(
+            "--verbose",
+            action="store_true",
+            default=False,
+            help="Show each policy's full definition (USING / WITH CHECK SQL).",
+        )
 
     def handle(self, *args: Any, **options: Any) -> None:  # noqa: ARG002
         """Check each RLSProtectedModel subclass and M2M through tables."""
         db_alias: str = options["database"]
         quiet: bool = options["quiet"]
+        verbose: bool = options["verbose"]
         table_to_model = _collect_rls_tables()
         m2m_tables = _collect_m2m_tables()
 
@@ -133,7 +149,9 @@ class Command(BaseCommand):
         if table_to_model:
             tables = list(table_to_model.keys())
             self._check_rls_status(tables, table_to_model, errors, db_alias=db_alias)
-            self._check_policies(tables, table_to_model, errors, db_alias=db_alias, quiet=quiet)
+            self._check_policies(
+                tables, table_to_model, errors, db_alias=db_alias, quiet=quiet, verbose=verbose
+            )
 
         # Check M2M through tables
         if m2m_tables:
@@ -143,7 +161,12 @@ class Command(BaseCommand):
             m2m_table_list = list(m2m_table_to_desc.keys())
             self._check_rls_status(m2m_table_list, m2m_table_to_desc, errors, db_alias=db_alias)
             self._check_policies(
-                m2m_table_list, m2m_table_to_desc, errors, db_alias=db_alias, quiet=quiet
+                m2m_table_list,
+                m2m_table_to_desc,
+                errors,
+                db_alias=db_alias,
+                quiet=quiet,
+                verbose=verbose,
             )
 
         if errors:
@@ -196,8 +219,14 @@ class Command(BaseCommand):
         *,
         db_alias: str = "default",
         quiet: bool = False,
+        verbose: bool = False,
     ) -> None:
-        """Batch-check RLS policies via ``pg_policies``."""
+        """Batch-check RLS policies via ``pg_policies``.
+
+        With ``verbose`` (and not ``quiet``), additionally read each policy's
+        live ``USING`` / ``WITH CHECK`` expressions from the ``pg_policy``
+        catalog and print them indented under the policy-name line.
+        """
         conn = connections[db_alias]
         with conn.cursor() as cursor:
             placeholders = ", ".join(["%s"] * len(tables))
@@ -213,9 +242,59 @@ class Command(BaseCommand):
             for row in cursor.fetchall():
                 policies_by_table.setdefault(row[0], []).append(row[1])
 
+            definitions_by_table: dict[str, list[tuple[str, str, str | None, str | None]]] = {}
+            if verbose and not quiet:
+                # ``pg_policies`` exposes only policy names; the ``pg_policy``
+                # catalog holds the live expressions, read back via
+                # ``pg_get_expr`` (the definition Postgres actually enforces).
+                # Same parameterised-table safety as the query above.
+                cursor.execute(
+                    f"SELECT c.relname, p.polname, p.polcmd, "
+                    f"pg_get_expr(p.polqual, p.polrelid), "
+                    f"pg_get_expr(p.polwithcheck, p.polrelid) "
+                    f"FROM pg_policy p JOIN pg_class c ON c.oid = p.polrelid "
+                    f"WHERE c.relname IN ({placeholders})",
+                    tables,
+                )
+                for relname, polname, polcmd, using, with_check in cursor.fetchall():
+                    definitions_by_table.setdefault(relname, []).append(
+                        (polname, polcmd, using, with_check)
+                    )
+
         for table, model_name in table_to_model.items():
             policies = policies_by_table.get(table, [])
             if not policies:
                 errors.append(f"  {model_name} ({table}): no RLS policies found")
             elif not quiet:
                 self.stdout.write(f"  {model_name} ({table}): {', '.join(policies)}")
+                if verbose:
+                    self._write_policy_details(definitions_by_table.get(table, []))
+
+    def _write_policy_details(
+        self,
+        definitions: list[tuple[str, str, str | None, str | None]],
+    ) -> None:
+        """Print the indented ``USING`` / ``WITH CHECK`` block for each policy."""
+        for polname, polcmd, using, with_check in definitions:
+            command = _POLCMD_LABELS.get(polcmd, polcmd)
+            self.stdout.write(f"    {polname} [{command}]")
+            self._write_clause("USING", using)
+            self._write_clause("WITH CHECK", with_check)
+
+    def _write_clause(self, label: str, expr: str | None) -> None:
+        """Print one policy clause, indenting each line of its expression.
+
+        ``pg_get_expr`` pretty-prints non-trivial expressions across several
+        lines, so the label goes on its own line and the expression is indented
+        beneath it (preserving Postgres's own formatting) rather than appended
+        inline. A ``NULL`` expression (e.g. an INSERT policy has no ``USING``)
+        is skipped.
+        """
+        if expr is None:
+            return
+        self.stdout.write(f"      {label}:")
+        # ``pg_get_expr`` returns a leading newline before the expression;
+        # strip it so the block starts cleanly, and avoid emitting trailing
+        # whitespace on any blank lines.
+        for line in expr.strip().splitlines():
+            self.stdout.write(f"        {line}" if line else "")

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -62,7 +62,7 @@ Quick wins that improve the debugging and development experience.
 
 Better CLI tooling and earlier misconfiguration detection.
 
-- [ ] **`check_rls --verbose`** — Show full RLS policy SQL for each table, not
+- [x] **`check_rls --verbose`** — Show full RLS policy SQL for each table, not
   just pass/fail status.
   *Why:* When policies exist but behave unexpectedly, seeing the actual SQL
   is the fastest way to diagnose the issue.

--- a/docs/guides/management-commands.md
+++ b/docs/guides/management-commands.md
@@ -11,6 +11,7 @@ have the expected RLS policies applied in the database.
 python manage.py check_rls
 python manage.py check_rls --database replica  # check a specific database
 python manage.py check_rls --quiet            # only print output on failure (for CI)
+python manage.py check_rls --verbose          # show each policy's USING / WITH CHECK SQL
 ```
 
 ### Successful Output
@@ -72,6 +73,7 @@ M2M through tables are auto-discovered by scanning `RLSProtectedModel` subclasse
 |------|---------|-------------|
 | `--database` | `default` | Database alias to check RLS status on |
 | `--quiet` | off | Suppress success output; only print errors (exit 1 on failure). Ideal for CI. |
+| `--verbose` | off | Show each policy's full definition (USING / WITH CHECK SQL) from the catalog. |
 
 ### Quiet Mode
 
@@ -80,10 +82,34 @@ the final summary line. On a fully-correct database, stdout is empty. Errors are
 suppressed: when RLS is missing or misconfigured, the command still writes the error
 report to stderr and exits with status code 1.
 
+### Verbose Mode
+
+`--verbose` prints the live policy definition from the `pg_policy` catalog (via
+`pg_get_expr()`) under each pass/fail line — the SQL expression PostgreSQL actually
+enforces, not a reconstruction. It complements the pass/fail check rather than replacing
+it: the exit code and error reporting are unchanged. `--quiet` and `--verbose` are
+logical opposites; `--quiet` takes precedence, so verbose detail only appears on a
+non-quiet run.
+
+```
+  Order (myapp_order): myapp_order_tenant_isolation_policy
+    myapp_order_tenant_isolation_policy [ALL]
+      USING:
+        CASE
+            WHEN (current_setting('rls.is_admin'::text, true) = 'true'::text) THEN true
+            ELSE (tenant_id = (NULLIF(current_setting('rls.current_tenant'::text, true), ''::text))::integer)
+        END
+      WITH CHECK:
+        CASE
+            WHEN (current_setting('rls.is_admin'::text, true) = 'true'::text) THEN true
+            ELSE (tenant_id = (NULLIF(current_setting('rls.current_tenant'::text, true), ''::text))::integer)
+        END
+```
+
 ### Limitations
 
 - Does not verify the **content** of the RLS policy (e.g., correct GUC variable names).
-  It only checks that a policy exists.
+  It only checks that a policy exists. Use `--verbose` to eyeball the policy body manually.
 - Does not check policies on non-`RLSProtectedModel` tables. If you manually manage
   RLS policies, use `assert_rls_policy_exists()` from the testing helpers.
 

--- a/docs/guides/management-commands.md
+++ b/docs/guides/management-commands.md
@@ -73,7 +73,7 @@ M2M through tables are auto-discovered by scanning `RLSProtectedModel` subclasse
 |------|---------|-------------|
 | `--database` | `default` | Database alias to check RLS status on |
 | `--quiet` | off | Suppress success output; only print errors (exit 1 on failure). Ideal for CI. |
-| `--verbose` | off | Show each policy's full definition (USING / WITH CHECK SQL) from the catalog. |
+| `--verbose` | off | Show each policy's full definition (USING / WITH CHECK SQL) from the `pg_policies` view. |
 
 ### Quiet Mode
 
@@ -84,12 +84,12 @@ report to stderr and exits with status code 1.
 
 ### Verbose Mode
 
-`--verbose` prints the live policy definition from the `pg_policy` catalog (via
-`pg_get_expr()`) under each pass/fail line — the SQL expression PostgreSQL actually
-enforces, not a reconstruction. It complements the pass/fail check rather than replacing
-it: the exit code and error reporting are unchanged. `--quiet` and `--verbose` are
-logical opposites; `--quiet` takes precedence, so verbose detail only appears on a
-non-quiet run.
+`--verbose` prints the live policy definition from the `pg_policies` view (its `qual` /
+`with_check` columns, which are PostgreSQL's own `pg_get_expr()` output) under each
+pass/fail line — the SQL expression PostgreSQL actually enforces, not a reconstruction.
+It complements the pass/fail check rather than replacing it: the exit code and error
+reporting are unchanged. `--quiet` and `--verbose` are logical opposites; `--quiet`
+takes precedence, so verbose detail only appears on a non-quiet run.
 
 ```
   Order (myapp_order): myapp_order_tenant_isolation_policy

--- a/tests/test_integration/test_end_to_end.py
+++ b/tests/test_integration/test_end_to_end.py
@@ -14,6 +14,7 @@ import pytest
 from django.core.management import call_command
 from django.db import connection
 
+from django_rls_tenants.management.commands.check_rls import Command as CheckRlsCommand
 from django_rls_tenants.rls.guc import get_guc, set_guc
 from django_rls_tenants.tenants.bypass import bypass_flag
 from django_rls_tenants.tenants.context import admin_context, tenant_context
@@ -420,6 +421,50 @@ class TestCheckRlsCommand:
         finally:
             with connection.cursor() as cur:
                 cur.execute('ALTER TABLE "test_order" ENABLE ROW LEVEL SECURITY')
+
+    def test_verbose_shows_policy_definitions(self):
+        """--verbose prints each policy's USING / WITH CHECK SQL from the catalog."""
+        out = StringIO()
+        call_command("check_rls", "--verbose", stdout=out)
+        output = out.getvalue()
+        # The command label and both expression clauses are shown...
+        assert "[ALL]" in output
+        assert "USING:" in output
+        assert "WITH CHECK:" in output
+        # ...with the live policy expression read back via pg_get_expr.
+        assert "current_setting" in output
+
+    def test_non_verbose_omits_policy_definitions(self):
+        """Without --verbose, policy expressions (USING) are not printed."""
+        out = StringIO()
+        call_command("check_rls", stdout=out)
+        output = out.getvalue()
+        assert "verified" in output.lower()  # command still ran successfully
+        assert "USING:" not in output
+        assert "current_setting" not in output
+
+    def test_quiet_overrides_verbose(self):
+        """--quiet wins over --verbose: no success/detail output on a clean run."""
+        out = StringIO()
+        call_command("check_rls", "--quiet", "--verbose", stdout=out)
+        assert out.getvalue() == ""
+
+    def test_verbose_skips_null_policy_clause(self):
+        """A NULL catalog clause is skipped rather than printed.
+
+        Every policy this package creates is ``FOR ALL`` with both ``USING`` and
+        ``WITH CHECK`` set, so the integration path never exercises a NULL clause
+        (e.g. a ``FOR INSERT`` policy has no ``USING``). Drive the formatter
+        directly to cover that defensive branch.
+        """
+        out = StringIO()
+        cmd = CheckRlsCommand(stdout=out)
+        cmd._write_clause("USING", None)
+        assert out.getvalue() == ""  # nothing printed for a NULL clause
+        cmd._write_clause("USING", "\nCASE WHEN true THEN true END")
+        rendered = out.getvalue()
+        assert "      USING:" in rendered
+        assert "        CASE WHEN true THEN true END" in rendered
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_integration/test_end_to_end.py
+++ b/tests/test_integration/test_end_to_end.py
@@ -466,6 +466,23 @@ class TestCheckRlsCommand:
         assert "      USING:" in rendered
         assert "        CASE WHEN true THEN true END" in rendered
 
+    def test_verbose_preserves_internal_blank_lines(self):
+        """A blank line inside an expression stays blank, with no trailing indent.
+
+        ``pg_get_expr`` can wrap a complex expression across lines; ``_write_clause``
+        indents each content line but must emit an empty string (not eight spaces)
+        for a blank one. Drive the formatter directly with a blank middle line,
+        since the policies this package creates render without internal blanks.
+        """
+        out = StringIO()
+        cmd = CheckRlsCommand(stdout=out)
+        cmd._write_clause("USING", "first line\n\nthird line")
+        lines = out.getvalue().split("\n")
+        assert lines[0] == "      USING:"
+        assert lines[1] == "        first line"
+        assert lines[2] == ""  # blank line preserved without indentation/trailing space
+        assert lines[3] == "        third line"
+
 
 # ---------------------------------------------------------------------------
 # EXPLAIN-based index usage verification


### PR DESCRIPTION
## Summary

Adds a `--verbose` flag to `check_rls` that prints each policy's live `USING` /
`WITH CHECK` definition under the existing pass/fail line — the SQL PostgreSQL
actually enforces — for auditing and diagnosing unexpected policy behaviour.

- Output is indented beneath each policy-name line, preserving Postgres's own
  pretty-printing of the expression.
- The pass/fail check, exit code, and error reporting are unchanged; verbose
  only *adds* detail.
- `--quiet` takes precedence over `--verbose` (no detail on a quiet run).

```
  Order (myapp_order): myapp_order_tenant_isolation_policy
    myapp_order_tenant_isolation_policy [ALL]
      USING:
        CASE
            WHEN (current_setting('rls.is_admin'::text, true) = 'true'::text) THEN true
            ELSE (tenant_id = (NULLIF(current_setting('rls.current_tenant'::text, true), ''::text))::integer)
        END
      WITH CHECK:
        ...
```

## Code review of the implementation

I reviewed the three feature commits and applied one cleanup
(`refactor:` commit on this branch):

- **Removed a redundant second catalog query.** The verbose path was issuing a
  separate `pg_policy`/`pg_class` query with `pg_get_expr()` and hand-mapping
  `polcmd` codes via a `_POLCMD_LABELS` dict. The `pg_policies` view that the
  first query *already* reads exposes exactly those values: `cmd` is the decoded
  command word and `qual` / `with_check` are `pg_get_expr(polqual/polwithcheck,
  polrelid)`. Selecting those three columns from the existing query drops a DB
  round-trip and the duplicated mapping, with **byte-identical output** (verified
  against the live `pg_policies` view definition). Deriving the name line and the
  detail block from the same rows also keeps their policy ordering consistent.
- **Added a formatter test** for blank-line preservation in a wrapped expression
  (the integration path never produces an internal blank line).
- **Corrected the docs** (CHANGELOG + management-commands guide) that referenced
  the now-unused `pg_policy` catalog.

No functional bugs were found in the original implementation; it was correct,
just more complex than necessary. (Note: `--verbose` coexists fine with Django's
built-in `--verbosity`/`-v`; only the abbreviation `--verb` is ambiguous, which
is standard argparse behaviour.)

## Test plan

- `ruff check .` ✅  `ruff format --check .` ✅  `mypy django_rls_tenants` ✅
- Full suite: **474 passed**, coverage **91.96%** (gate 90%); all verbose code
  paths covered.
- `mkdocs build --strict` ✅

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CqumNqavvCq27dN5ZWGBhh