### PR TITLE
feat: add W008/W009 system checks (#29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   are given.
 - **System checks `W008` + `W009`** (#29): `W008` warns when
   `RLS_TENANTS['TENANT_MODEL']` does not resolve to an installed model;
-  `W009` warns when a concrete `RLSProtectedModel` subclass has no field
-  named `TENANT_FK_FIELD`. Both surface the misconfiguration at startup via
-  `manage.py check` instead of as a cryptic error at migrate/query time.
+  `W009` warns when a concrete `RLSProtectedModel` subclass is missing the
+  tenant field its RLS policy references (resolved from `RLSConstraint(field=…)`,
+  falling back to `TENANT_FK_FIELD`). Both surface the misconfiguration at
+  startup via `manage.py check` instead of as a cryptic error at
+  migrate/query time.
 
 ## [1.2.1] - 2026-06-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   PostgreSQL actually enforces) under the pass/fail line, for auditing and
   diagnosing unexpected policy behaviour. `--quiet` takes precedence when both
   are given.
+- **System checks `W008` + `W009`** (#29): `W008` warns when
+  `RLS_TENANTS['TENANT_MODEL']` does not resolve to an installed model;
+  `W009` warns when a concrete `RLSProtectedModel` subclass has no field
+  named `TENANT_FK_FIELD`. Both surface the misconfiguration at startup via
+  `manage.py check` instead of as a cryptic error at migrate/query time.
 
 ## [1.2.1] - 2026-06-27
 

--- a/django_rls_tenants/tenants/checks.py
+++ b/django_rls_tenants/tenants/checks.py
@@ -9,6 +9,8 @@ silent failures at runtime:
 - ``CONN_MAX_AGE > 0`` with ``USE_LOCAL_SET=False`` (connection-pool GUC leak risk).
 - ``DATABASES`` contains aliases not in ``settings.DATABASES``.
 - ``USE_LOCAL_SET=True`` without ``ATOMIC_REQUESTS`` on configured databases.
+- ``TENANT_MODEL`` does not resolve to an installed model.
+- ``TENANT_FK_FIELD`` missing on an ``RLSProtectedModel`` subclass.
 """
 
 from __future__ import annotations
@@ -39,6 +41,8 @@ def check_rls_config(
     errors.extend(_check_conn_max_age_with_session_gucs())
     errors.extend(_check_databases_alias_exists())
     errors.extend(_check_databases_atomic_requests())
+    errors.extend(_check_tenant_model_resolves())
+    errors.extend(_check_tenant_fk_field_exists())
     return errors
 
 
@@ -257,6 +261,83 @@ def _check_databases_atomic_requests() -> list[CheckWarning]:
                     f"setting GUCs on {alias!r}.",
                     hint=f"Set DATABASES[{alias!r}]['ATOMIC_REQUESTS'] = True.",
                     id="django_rls_tenants.W007",
+                )
+            )
+    return warnings
+
+
+def _check_tenant_model_resolves() -> list[CheckWarning]:
+    """Warn if ``TENANT_MODEL`` does not resolve to an installed model.
+
+    ``RLS_TENANTS["TENANT_MODEL"]`` must be a ``"<app_label>.<ModelName>"``
+    path to a model in ``INSTALLED_APPS``. A typo or an app missing from
+    ``INSTALLED_APPS`` otherwise surfaces only at query time -- when the
+    tenant FK is resolved -- with a cryptic ``LookupError``.
+    """
+    from django.apps import apps  # noqa: PLC0415
+
+    from django_rls_tenants.exceptions import RLSConfigurationError  # noqa: PLC0415
+    from django_rls_tenants.tenants.conf import rls_tenants_config  # noqa: PLC0415
+
+    warnings: list[CheckWarning] = []
+    try:
+        model_path = rls_tenants_config.TENANT_MODEL
+    except RLSConfigurationError:
+        # TENANT_MODEL is required; its absence is reported when the config
+        # is first read elsewhere. Don't crash the check here.
+        return warnings
+
+    try:
+        apps.get_model(model_path)
+    except (LookupError, ValueError):
+        # ValueError: malformed path (not "app_label.ModelName").
+        # LookupError: unknown app label or model name.
+        warnings.append(
+            CheckWarning(
+                f"RLS_TENANTS['TENANT_MODEL'] = {model_path!r} does not "
+                f"resolve to an installed model.",
+                hint=(
+                    "Set TENANT_MODEL to '<app_label>.<ModelName>' for a model in INSTALLED_APPS."
+                ),
+                id="django_rls_tenants.W008",
+            )
+        )
+    return warnings
+
+
+def _check_tenant_fk_field_exists() -> list[CheckWarning]:
+    """Warn if an ``RLSProtectedModel`` subclass lacks the tenant FK field.
+
+    ``RLSProtectedModel`` injects a tenant ``ForeignKey`` named after
+    ``RLS_TENANTS["TENANT_FK_FIELD"]`` (default ``"tenant"``). If a subclass
+    declares its own tenant field under a different name -- or
+    ``TENANT_FK_FIELD`` is changed to a name no model actually defines -- the
+    generated RLS policy references a column that doesn't exist, failing at
+    migrate/query time. This catches that mismatch at startup.
+    """
+    from django.apps import apps  # noqa: PLC0415
+    from django.core.exceptions import FieldDoesNotExist  # noqa: PLC0415
+
+    from django_rls_tenants.tenants.conf import rls_tenants_config  # noqa: PLC0415
+    from django_rls_tenants.tenants.models import RLSProtectedModel  # noqa: PLC0415
+
+    warnings: list[CheckWarning] = []
+    fk_field = rls_tenants_config.TENANT_FK_FIELD
+    for model in apps.get_models():
+        if not issubclass(model, RLSProtectedModel) or model._meta.abstract:  # noqa: SLF001
+            continue
+        try:
+            model._meta.get_field(fk_field)  # noqa: SLF001
+        except FieldDoesNotExist:
+            warnings.append(
+                CheckWarning(
+                    f"{model.__name__} has no field {fk_field!r} "
+                    f"(RLS_TENANTS['TENANT_FK_FIELD']).",
+                    hint=(
+                        "Add the tenant ForeignKey, or set TENANT_FK_FIELD to the correct name."
+                    ),
+                    id="django_rls_tenants.W009",
+                    obj=model,
                 )
             )
     return warnings

--- a/django_rls_tenants/tenants/checks.py
+++ b/django_rls_tenants/tenants/checks.py
@@ -306,35 +306,48 @@ def _check_tenant_model_resolves() -> list[CheckWarning]:
 
 
 def _check_tenant_fk_field_exists() -> list[CheckWarning]:
-    """Warn if an ``RLSProtectedModel`` subclass lacks the tenant FK field.
+    """Warn if a concrete ``RLSProtectedModel`` subclass lacks its tenant field.
 
-    ``RLSProtectedModel`` injects a tenant ``ForeignKey`` named after
-    ``RLS_TENANTS["TENANT_FK_FIELD"]`` (default ``"tenant"``). If a subclass
-    declares its own tenant field under a different name -- or
-    ``TENANT_FK_FIELD`` is changed to a name no model actually defines -- the
-    generated RLS policy references a column that doesn't exist, failing at
-    migrate/query time. This catches that mismatch at startup.
+    Each model's ``RLSConstraint`` generates an RLS policy that filters on a
+    tenant column. The referenced field name comes from the model's
+    ``RLSConstraint(field=...)`` when present, falling back to
+    ``RLS_TENANTS["TENANT_FK_FIELD"]`` (default ``"tenant"``) -- the same
+    resolution order ``register_m2m_rls`` uses.
+
+    If that field is missing -- e.g. a constraint's ``field`` (or
+    ``TENANT_FK_FIELD``) names a column no model actually defines -- the
+    generated policy references a column that doesn't exist, failing at
+    migrate/query time. This catches the mismatch at startup.
+
+    The field name is resolved from the constraint rather than blindly from
+    ``TENANT_FK_FIELD``: the ``class_prepared`` injector always adds a field
+    named ``TENANT_FK_FIELD``, so checking that name alone would always pass.
+    The policy uses the *constraint's* field, so that is what must exist.
     """
     from django.apps import apps  # noqa: PLC0415
     from django.core.exceptions import FieldDoesNotExist  # noqa: PLC0415
 
     from django_rls_tenants.tenants.conf import rls_tenants_config  # noqa: PLC0415
-    from django_rls_tenants.tenants.models import RLSProtectedModel  # noqa: PLC0415
+    from django_rls_tenants.tenants.models import (  # noqa: PLC0415
+        RLSProtectedModel,
+        _get_tenant_fk_field,
+    )
 
     warnings: list[CheckWarning] = []
-    fk_field = rls_tenants_config.TENANT_FK_FIELD
+    default_fk_field = rls_tenants_config.TENANT_FK_FIELD
     for model in apps.get_models():
         if not issubclass(model, RLSProtectedModel) or model._meta.abstract:  # noqa: SLF001
             continue
+        fk_field = _get_tenant_fk_field(model) or default_fk_field
         try:
             model._meta.get_field(fk_field)  # noqa: SLF001
         except FieldDoesNotExist:
             warnings.append(
                 CheckWarning(
-                    f"{model.__name__} has no field {fk_field!r} "
-                    f"(RLS_TENANTS['TENANT_FK_FIELD']).",
+                    f"{model.__name__} has no field {fk_field!r} referenced by its RLS policy.",
                     hint=(
-                        "Add the tenant ForeignKey, or set TENANT_FK_FIELD to the correct name."
+                        "Add the tenant ForeignKey, or set TENANT_FK_FIELD "
+                        "(or the constraint's field=) to the correct name."
                     ),
                     id="django_rls_tenants.W009",
                     obj=model,

--- a/docs/advanced/architecture.md
+++ b/docs/advanced/architecture.md
@@ -50,7 +50,7 @@ The upper layer builds Django multitenancy on top of `rls/`:
 | `tenants/testing.py` | Test helpers: `rls_bypass`, `rls_as_tenant`, assertion functions |
 | `tenants/types.py` | `TenantUser` protocol |
 | `tenants/state.py` | `get_current_tenant_id()`, `set_current_tenant_id()`, `reset_current_tenant_id()` -- `ContextVar`-based tenant state for auto-scoping. Also `get_rls_context_active()`, `set_rls_context_active()`, `reset_rls_context_active()` -- tracks whether any RLS context is active (used by strict mode) |
-| `tenants/checks.py` | Django system checks (W001--W007) |
+| `tenants/checks.py` | Django system checks (W001--W009) |
 
 ### Import Boundary
 

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -75,7 +75,7 @@ Better CLI tooling and earlier misconfiguration detection.
   *Why:* DBAs and security reviewers need to audit what SQL will run before
   approving it.
 
-- [ ] **New system checks** — `W008`: verify `TENANT_MODEL` resolves to an
+- [x] **New system checks** — `W008`: verify `TENANT_MODEL` resolves to an
   installed model at startup; `W009`: verify `TENANT_FK_FIELD` exists on all
   `RLSProtectedModel` subclasses.
   *Why:* These misconfigurations currently fail at query time with cryptic

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -244,6 +244,8 @@ django-rls-tenants registers Django system checks that warn about common misconf
 | `W005` | Warning | Database connection uses a PostgreSQL superuser (RLS bypassed) |
 | `W006` | Warning | `DATABASES` contains an alias not defined in `settings.DATABASES` |
 | `W007` | Warning | `USE_LOCAL_SET=True` without `ATOMIC_REQUESTS` on a configured alias |
+| `W008` | Warning | `RLS_TENANTS['TENANT_MODEL']` does not resolve to an installed model |
+| `W009` | Warning | `TENANT_FK_FIELD` missing on an `RLSProtectedModel` subclass |
 
 Run `python manage.py check` to see any warnings.
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -245,7 +245,7 @@ django-rls-tenants registers Django system checks that warn about common misconf
 | `W006` | Warning | `DATABASES` contains an alias not defined in `settings.DATABASES` |
 | `W007` | Warning | `USE_LOCAL_SET=True` without `ATOMIC_REQUESTS` on a configured alias |
 | `W008` | Warning | `RLS_TENANTS['TENANT_MODEL']` does not resolve to an installed model |
-| `W009` | Warning | `TENANT_FK_FIELD` missing on an `RLSProtectedModel` subclass |
+| `W009` | Warning | Tenant field referenced by an `RLSProtectedModel`'s RLS policy is missing |
 
 Run `python manage.py check` to see any warnings.
 

--- a/tests/test_tenants/test_checks.py
+++ b/tests/test_tenants/test_checks.py
@@ -14,6 +14,8 @@ from django_rls_tenants.tenants.checks import (
     _check_databases_atomic_requests,
     _check_guc_prefix_mismatch,
     _check_superuser_connection,
+    _check_tenant_fk_field_exists,
+    _check_tenant_model_resolves,
     _check_use_local_set_requires_atomic,
     check_rls_config,
 )
@@ -518,3 +520,125 @@ class TestCheckDatabasesAtomicRequests:
             warnings = _check_databases_atomic_requests()
         ids = [w.id for w in warnings]
         assert ids.count("django_rls_tenants.W007") == 2
+
+
+class TestCheckTenantModelResolves:
+    """Tests for _check_tenant_model_resolves (W008)."""
+
+    def test_no_warning_when_model_resolves(self):
+        """No W008 when TENANT_MODEL points at an installed model."""
+        with (
+            override_settings(RLS_TENANTS={"TENANT_MODEL": "test_app.Tenant"}),
+            patch(_CONF_PATCH, RLSTenantsConfig()),
+        ):
+            warnings = _check_tenant_model_resolves()
+        assert warnings == []
+
+    def test_w008_unknown_model_name(self):
+        """W008 fires when the app exists but the model name does not (LookupError)."""
+        with (
+            override_settings(RLS_TENANTS={"TENANT_MODEL": "test_app.DoesNotExist"}),
+            patch(_CONF_PATCH, RLSTenantsConfig()),
+        ):
+            warnings = _check_tenant_model_resolves()
+        ids = [w.id for w in warnings]
+        assert "django_rls_tenants.W008" in ids
+
+    def test_w008_unknown_app_label(self):
+        """W008 fires when the app label is not installed (LookupError)."""
+        with (
+            override_settings(RLS_TENANTS={"TENANT_MODEL": "nonexistent_app.Tenant"}),
+            patch(_CONF_PATCH, RLSTenantsConfig()),
+        ):
+            warnings = _check_tenant_model_resolves()
+        ids = [w.id for w in warnings]
+        assert "django_rls_tenants.W008" in ids
+
+    def test_w008_malformed_path(self):
+        """W008 fires when TENANT_MODEL is not an 'app_label.ModelName' path (ValueError)."""
+        with (
+            override_settings(RLS_TENANTS={"TENANT_MODEL": "notdotted"}),
+            patch(_CONF_PATCH, RLSTenantsConfig()),
+        ):
+            warnings = _check_tenant_model_resolves()
+        ids = [w.id for w in warnings]
+        assert "django_rls_tenants.W008" in ids
+
+    def test_w008_message_includes_model_path(self):
+        """W008 message includes the offending model path."""
+        with (
+            override_settings(RLS_TENANTS={"TENANT_MODEL": "test_app.DoesNotExist"}),
+            patch(_CONF_PATCH, RLSTenantsConfig()),
+        ):
+            warnings = _check_tenant_model_resolves()
+        assert "test_app.DoesNotExist" in warnings[0].msg
+        assert isinstance(warnings[0], CheckWarning)
+
+    def test_no_warning_when_tenant_model_unset(self):
+        """No crash and no W008 when TENANT_MODEL is missing (reported elsewhere)."""
+        with (
+            override_settings(RLS_TENANTS={}),
+            patch(_CONF_PATCH, RLSTenantsConfig()),
+        ):
+            warnings = _check_tenant_model_resolves()
+        assert warnings == []
+
+
+class TestCheckTenantFkFieldExists:
+    """Tests for _check_tenant_fk_field_exists (W009)."""
+
+    def test_no_warning_with_default_fk_field(self):
+        """No W009 when TENANT_FK_FIELD matches the FK every model defines."""
+        with (
+            override_settings(RLS_TENANTS={"TENANT_MODEL": "test_app.Tenant"}),
+            patch(_CONF_PATCH, RLSTenantsConfig()),
+        ):
+            warnings = _check_tenant_fk_field_exists()
+        assert warnings == []
+
+    def test_w009_fires_for_nonexistent_fk_field(self):
+        """W009 fires when TENANT_FK_FIELD names a field no model defines."""
+        with (
+            override_settings(
+                RLS_TENANTS={
+                    "TENANT_MODEL": "test_app.Tenant",
+                    "TENANT_FK_FIELD": "nonexistent",
+                },
+            ),
+            patch(_CONF_PATCH, RLSTenantsConfig()),
+        ):
+            warnings = _check_tenant_fk_field_exists()
+        ids = [w.id for w in warnings]
+        assert "django_rls_tenants.W009" in ids
+
+    def test_w009_fires_once_per_protected_model(self):
+        """W009 reports every concrete RLSProtectedModel subclass that lacks the field."""
+        with (
+            override_settings(
+                RLS_TENANTS={
+                    "TENANT_MODEL": "test_app.Tenant",
+                    "TENANT_FK_FIELD": "nonexistent",
+                },
+            ),
+            patch(_CONF_PATCH, RLSTenantsConfig()),
+        ):
+            warnings = _check_tenant_fk_field_exists()
+        # Multiple RLSProtectedModel subclasses exist in test_app.
+        assert len(warnings) >= 2
+        assert all(w.id == "django_rls_tenants.W009" for w in warnings)
+
+    def test_w009_message_and_obj(self):
+        """W009 names the missing field and binds the warning to the offending model."""
+        with (
+            override_settings(
+                RLS_TENANTS={
+                    "TENANT_MODEL": "test_app.Tenant",
+                    "TENANT_FK_FIELD": "nonexistent",
+                },
+            ),
+            patch(_CONF_PATCH, RLSTenantsConfig()),
+        ):
+            warnings = _check_tenant_fk_field_exists()
+        assert "nonexistent" in warnings[0].msg
+        assert warnings[0].obj is not None
+        assert isinstance(warnings[0], CheckWarning)

--- a/tests/test_tenants/test_checks.py
+++ b/tests/test_tenants/test_checks.py
@@ -587,17 +587,23 @@ class TestCheckTenantModelResolves:
 class TestCheckTenantFkFieldExists:
     """Tests for _check_tenant_fk_field_exists (W009)."""
 
-    def test_no_warning_with_default_fk_field(self):
-        """No W009 when TENANT_FK_FIELD matches the FK every model defines."""
-        with (
-            override_settings(RLS_TENANTS={"TENANT_MODEL": "test_app.Tenant"}),
-            patch(_CONF_PATCH, RLSTenantsConfig()),
-        ):
-            warnings = _check_tenant_fk_field_exists()
+    # The check resolves the policy field via this canonical helper; patching
+    # it lets us simulate a constraint that references a missing column.
+    _RESOLVER_PATCH = "django_rls_tenants.tenants.models._get_tenant_fk_field"
+
+    def test_no_warning_with_default_config(self):
+        """No W009 when every model's RLS-policy field exists (default ``tenant``)."""
+        warnings = _check_tenant_fk_field_exists()
         assert warnings == []
 
-    def test_w009_fires_for_nonexistent_fk_field(self):
-        """W009 fires when TENANT_FK_FIELD names a field no model defines."""
+    def test_no_warning_when_only_tenant_fk_field_changed(self):
+        """Changing TENANT_FK_FIELD alone does not fire: the policy uses the constraint field.
+
+        Regression guard against a tautological check. The ``class_prepared``
+        injector always adds a field named ``TENANT_FK_FIELD``, so the policy
+        filters on the constraint's ``field`` (``"tenant"`` here), which still
+        exists -- no column is actually missing.
+        """
         with (
             override_settings(
                 RLS_TENANTS={
@@ -607,28 +613,26 @@ class TestCheckTenantFkFieldExists:
             ),
             patch(_CONF_PATCH, RLSTenantsConfig()),
         ):
+            warnings = _check_tenant_fk_field_exists()
+        assert warnings == []
+
+    def test_w009_fires_when_policy_field_missing(self):
+        """W009 fires when the resolved policy field names a column no model defines."""
+        with patch(self._RESOLVER_PATCH, return_value="nonexistent"):
             warnings = _check_tenant_fk_field_exists()
         ids = [w.id for w in warnings]
         assert "django_rls_tenants.W009" in ids
 
     def test_w009_fires_once_per_protected_model(self):
         """W009 reports every concrete RLSProtectedModel subclass that lacks the field."""
-        with (
-            override_settings(
-                RLS_TENANTS={
-                    "TENANT_MODEL": "test_app.Tenant",
-                    "TENANT_FK_FIELD": "nonexistent",
-                },
-            ),
-            patch(_CONF_PATCH, RLSTenantsConfig()),
-        ):
+        with patch(self._RESOLVER_PATCH, return_value="nonexistent"):
             warnings = _check_tenant_fk_field_exists()
         # Multiple RLSProtectedModel subclasses exist in test_app.
         assert len(warnings) >= 2
         assert all(w.id == "django_rls_tenants.W009" for w in warnings)
 
-    def test_w009_message_and_obj(self):
-        """W009 names the missing field and binds the warning to the offending model."""
+    def test_w009_falls_back_to_tenant_fk_field_without_constraint(self):
+        """When a model has no RLSConstraint, the check falls back to TENANT_FK_FIELD."""
         with (
             override_settings(
                 RLS_TENANTS={
@@ -637,7 +641,15 @@ class TestCheckTenantFkFieldExists:
                 },
             ),
             patch(_CONF_PATCH, RLSTenantsConfig()),
+            patch(self._RESOLVER_PATCH, return_value=None),
         ):
+            warnings = _check_tenant_fk_field_exists()
+        ids = [w.id for w in warnings]
+        assert "django_rls_tenants.W009" in ids
+
+    def test_w009_message_and_obj(self):
+        """W009 names the missing field and binds the warning to the offending model."""
+        with patch(self._RESOLVER_PATCH, return_value="nonexistent"):
             warnings = _check_tenant_fk_field_exists()
         assert "nonexistent" in warnings[0].msg
         assert warnings[0].obj is not None


### PR DESCRIPTION
## Summary

Implements issue #29 — Django system checks **W008** and **W009** — and includes a follow-up correctness fix found during a deep review of the three implementation commits.

- **W008** — warns when `RLS_TENANTS['TENANT_MODEL']` does not resolve to an installed model (bad app label, unknown model name, or malformed path).
- **W009** — warns when a concrete `RLSProtectedModel` subclass is missing the tenant field its RLS policy references.

Both surface misconfiguration at startup via `manage.py check` instead of as a cryptic error at migrate/query time.

## Review finding & fix (W009)

The original W009 (commit `737cdd9`) checked `get_field(TENANT_FK_FIELD)`. But the `class_prepared` injector in `tenants/models.py` **always** adds a field named `TENANT_FK_FIELD`, so the check could **never fire in a real process** — it was tautological. The test only tripped it by patching the config singleton to diverge from what the models were built with, a state unreachable at runtime.

The RLS policy actually filters on the **constraint's** field (`RLSConstraint(field=...)`, `"tenant"` by default in `RLSProtectedModel.Meta`), not on `TENANT_FK_FIELD`. The fix resolves the checked field via `_get_tenant_fk_field()` — the same canonical resolver `register_m2m_rls` already uses — falling back to `TENANT_FK_FIELD` for models without an `RLSConstraint`. W009 now catches the genuine misconfiguration: a policy referencing a column the table doesn't have.

This is exactly the design point the implementation plan flagged: *"reconcile the check against `_get_tenant_fk_field()` so it neither always-passes nor always-fires."*

W008 and the rest of the implementation reviewed as correct and were left unchanged.

## Tests

W009 tests rewritten to exercise the **genuine** firing path (a constraint whose field is missing) and the fallback branch, plus a **regression guard** asserting that changing `TENANT_FK_FIELD` alone no longer trips the check.

- Full suite: **486 passed**, coverage **92.14%** (gate 90%); `tenants/checks.py` at 99%.
- `ruff check`, `ruff format --check`, and `mypy --strict` all clean repo-wide.

## Docs

- `CHANGELOG.md` and `docs/getting-started/configuration.md` updated to describe W009's actual semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CqumNqavvCq27dN5ZWGBhh
