### PR TITLE
docs: add Celery quick-start guide (#30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   falling back to `TENANT_FK_FIELD`). Both surface the misconfiguration at
   startup via `manage.py check` instead of as a cryptic error at
   migrate/query time.
+- **Documentation: Celery quick-start guide** (#30): new Celery Tasks guide
+  showing how to wrap task bodies in `tenant_context()` so RLS context is set
+  for work that runs outside the request cycle. Interim pattern until native
+  Celery integration lands in v1.3.0.
 
 ## [1.2.1] - 2026-06-27
 

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -81,7 +81,7 @@ Better CLI tooling and earlier misconfiguration detection.
   *Why:* These misconfigurations currently fail at query time with cryptic
   errors instead of being caught at startup.
 
-- [ ] **Documentation: Celery quick-start** — Minimal pattern for wrapping Celery
+- [x] **Documentation: Celery quick-start** — Minimal pattern for wrapping Celery
   tasks with `tenant_context()` before full Celery integration lands in v1.3.0.
   *Why:* Celery is the most common question from new users — a docs page
   unblocks them immediately without waiting for library-level support.

--- a/docs/guides/celery-tasks.md
+++ b/docs/guides/celery-tasks.md
@@ -1,0 +1,125 @@
+# Celery Tasks
+
+Celery tasks run outside the request/response cycle, so `RLSTenantMiddleware`
+never sets the RLS context for them. Each task must establish its own context
+explicitly -- otherwise, queries against RLS-protected models return zero rows
+(fail-closed), or raise `NoTenantContextError` when `STRICT_MODE` is enabled.
+
+!!! note
+    Native Celery integration (automatic context propagation without manual
+    wiring) is planned for v1.3.0. This page documents the interim pattern.
+
+## Core Pattern
+
+Pass `tenant_id` as a task argument and wrap the task body in `tenant_context()`:
+
+```python
+from celery import shared_task
+from django_rls_tenants import tenant_context
+
+
+@shared_task
+def process_orders(tenant_id: int) -> None:
+    with tenant_context(tenant_id):
+        for order in Order.objects.all():   # scoped to this tenant
+            ...
+```
+
+!!! warning
+    Pass the tenant **id** (an `int` or `str`), never a model instance. Celery
+    serialises task arguments, and a serialised model instance is both wasteful
+    and can go stale before the task executes.
+
+!!! warning
+    Every task that queries RLS-protected models must set a context. A task that
+    forgets gets zero rows (fail-closed), or raises `NoTenantContextError` when
+    `STRICT_MODE=True`.
+
+## Enqueuing from a Request
+
+The current tenant's ID is typically available as `request.user.rls_tenant_id`:
+
+```python
+# In a view:
+process_orders.delay(request.user.rls_tenant_id)
+```
+
+## Cross-Tenant and Scheduled Tasks
+
+For periodic (beat) tasks that operate across all tenants, use `admin_context()`
+to read the tenant list, then re-enter `tenant_context()` for each tenant:
+
+```python
+from celery import shared_task
+from django_rls_tenants import admin_context, tenant_context
+
+
+@shared_task
+def nightly_billing() -> None:
+    with admin_context():
+        tenants = Tenant.objects.all()
+        for tenant in tenants:
+            with tenant_context(tenant_id=tenant.pk):
+                _process_orders(tenant)
+
+
+def _process_orders(tenant: Tenant) -> None:
+    orders = Order.objects.filter(status="pending")
+    for order in orders:
+        order.process()
+```
+
+!!! warning
+    `admin_context()` bypasses tenant isolation entirely -- it sees every
+    tenant's data. Keep its body minimal: use it only to fetch the tenant list,
+    then scope each operation back down with `tenant_context()`. Never mix in
+    user-supplied tenant filtering inside `admin_context()`.
+
+## Reusable Decorator
+
+To avoid repeating the `with tenant_context(tenant_id):` block in every task,
+write a thin decorator that reads `tenant_id` from the first argument:
+
+```python
+import functools
+from django_rls_tenants import tenant_context
+
+
+def with_tenant_context(func):
+    """Decorator that opens tenant_context(tenant_id) around the task body.
+
+    Expects ``tenant_id`` as the first positional argument.
+    """
+    @functools.wraps(func)
+    def wrapper(tenant_id, *args, **kwargs):
+        with tenant_context(tenant_id):
+            return func(tenant_id, *args, **kwargs)
+    return wrapper
+```
+
+```python
+from celery import shared_task
+
+
+@shared_task
+@with_tenant_context
+def process_orders(tenant_id: int) -> None:
+    for order in Order.objects.all():   # already scoped by decorator
+        ...
+```
+
+!!! tip
+    In multi-database setups, pass `using="..."` to `tenant_context()` to scope
+    queries on a specific database alias:
+
+    ```python
+    with tenant_context(tenant_id, using="replica"):
+        orders = Order.objects.using("replica").all()
+    ```
+
+    See [Context Managers](context-managers.md#multi-database-support) for details.
+
+!!! note
+    See [Context Managers](context-managers.md) for the full `tenant_context()` and
+    `admin_context()` API -- including nesting, debug logging, and strict mode
+    interaction. Native Celery integration is on the v1.3.0 roadmap.

--- a/docs/guides/celery-tasks.md
+++ b/docs/guides/celery-tasks.md
@@ -108,6 +108,12 @@ def process_orders(tenant_id: int) -> None:
         ...
 ```
 
+!!! warning
+    This decorator assumes `tenant_id` is the **first positional argument**, so it
+    does not work with bound tasks (`@shared_task(bind=True)`) -- there Celery passes
+    the task instance first, and `tenant_id` would receive `self`. For bound tasks,
+    keep the explicit `with tenant_context(tenant_id):` block in the task body instead.
+
 !!! tip
     In multi-database setups, pass `using="..."` to `tenant_context()` to scope
     queries on a specific database alias:

--- a/docs/guides/middleware.md
+++ b/docs/guides/middleware.md
@@ -210,4 +210,4 @@ with admin_context():
     all_users = User.objects.all()
 ```
 
-See [Context Managers](context-managers.md) for details.
+See [Context Managers](context-managers.md) and [Celery Tasks](celery-tasks.md) for details.

--- a/docs/guides/user-integration.md
+++ b/docs/guides/user-integration.md
@@ -169,6 +169,8 @@ def process_batch(tenant_id: int):
         ...
 ```
 
+For a full Celery integration pattern using `tenant_context()` directly, see [Celery Tasks](celery-tasks.md).
+
 ## Runtime Type Checking
 
 `TenantUser` is decorated with `@runtime_checkable`, so you can use `isinstance()`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,7 @@ nav:
       - User Integration: guides/user-integration.md
       - Middleware: guides/middleware.md
       - Context Managers: guides/context-managers.md
+      - Celery Tasks: guides/celery-tasks.md
       - Bypass Mode: guides/bypass-mode.md
       - Testing: guides/testing.md
       - Management Commands: guides/management-commands.md


### PR DESCRIPTION
## Summary

Adds the **Celery Tasks** quick-start guide (closes #30) — the interim pattern for setting RLS context in Celery tasks until native integration lands in v1.3.0. Includes a deep-review refinement on top of the original commit.

Celery tasks run outside the request/response cycle, so `RLSTenantMiddleware` never sets the RLS context — each task must establish its own. The guide covers:

- **Core pattern** — pass `tenant_id` as a task arg, wrap the body in `tenant_context()`.
- **Enqueuing from a request** — `process_orders.delay(request.user.rls_tenant_id)`.
- **Cross-tenant / beat tasks** — `admin_context()` to read the tenant list, then `tenant_context()` per tenant.
- **Reusable decorator** — a thin `with_tenant_context` wrapper.
- Multi-database (`using=`) tip and cross-links to the Context Managers guide.

Also registers the page in the mkdocs nav, adds the CHANGELOG entry, ticks the roadmap item, and cross-links the existing Celery snippets in the middleware and user-integration guides.

## Deep review findings

Reviewed every code snippet against the actual source:

- ✅ All API usage is accurate — `tenant_context()` / `admin_context()` signatures (incl. positional/keyword `tenant_id` and keyword-only `using=`), top-level exports, `NoTenantContextError`, `STRICT_MODE`, and `rls_tenant_id` all match the implementation.
- ✅ All cross-links resolve — verified `context-managers.md#multi-database-support` against the generated anchor in the built HTML.
- ✅ Decorator stacking order (`@shared_task` outermost) is correct.

**One robustness gap fixed:** the reusable `with_tenant_context` decorator reads `tenant_id` from the first positional argument, which silently breaks under `@shared_task(bind=True)` (Celery passes the task instance as the first arg, so `tenant_id` would receive `self`). Added a `!!! warning` telling readers to keep the explicit `with tenant_context(tenant_id):` block in bound tasks.

## Verification

- `mkdocs build --strict` — passes (exit 0), all internal links/anchors resolve
- `ruff check .` / `ruff format --check .` — clean
- `mypy django_rls_tenants` — no issues
- `pytest` — 474 passed, coverage 91.96% (≥90% gate)
- pre-commit hooks — pass on the changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)