### PR TITLE
docs: adopt Contributor Covenant Code of Conduct (#35)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -3,6 +3,12 @@
 Thank you for considering a contribution. This guide covers everything you need to get
 started.
 
+## Code of Conduct
+
+This project and everyone participating in it is governed by the
+[Contributor Covenant Code of Conduct](../CODE_OF_CONDUCT.md). By participating, you are
+expected to uphold this code. Please report unacceptable behavior to dvoraj75@gmail.com.
+
 ## Prerequisites
 
 - Python 3.11+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Code of Conduct** (#35): adopted the Contributor Covenant v2.1
+  (`CODE_OF_CONDUCT.md`), linked from the contributing guides and the
+  documentation. Enforcement contact: dvoraj75@gmail.com.
+
 ## [1.2.2] - 2026-06-27
 
 ### Added

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+dvoraj75@gmail.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ Are you using `django-rls-tenants` in production? We'd love to hear about it.
 | Django     | >= 4.2  |
 | PostgreSQL | >= 15   |
 
+## Contributing
+
+Contributions are welcome! See the [contributing guide](.github/CONTRIBUTING.md) to get
+started. This project is governed by the
+[Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md).
+
 ## License
 
 [MIT](LICENSE)

--- a/docs/development/code-of-conduct.md
+++ b/docs/development/code-of-conduct.md
@@ -1,0 +1,1 @@
+--8<-- "CODE_OF_CONDUCT.md"

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -3,6 +3,12 @@
 Thank you for considering a contribution to django-rls-tenants. This guide covers
 everything you need to get started.
 
+## Code of Conduct
+
+This project and everyone participating in it is governed by the
+[Contributor Covenant Code of Conduct](code-of-conduct.md). By participating, you are
+expected to uphold this code. Please report unacceptable behavior to dvoraj75@gmail.com.
+
 ## Prerequisites
 
 - Python 3.11+

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -115,7 +115,7 @@ Highest adoption impact, no new dependencies.
   `tenant_context()`?") and make system check hints more actionable.
   *Why:* Reduces time-to-fix for new users hitting common misconfiguration.
 
-- [ ] **CODE_OF_CONDUCT.md** — Adopt the Contributor Covenant.
+- [x] **CODE_OF_CONDUCT.md** — Adopt the Contributor Covenant.
   *Why:* Standard open-source practice that signals project maturity and
   welcoming community.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -99,4 +99,5 @@ nav:
       - API: reference/api.md
   - Development:
       - Contributing: development/contributing.md
+      - Code of Conduct: development/code-of-conduct.md
       - Changelog: development/changelog.md


### PR DESCRIPTION
## Related Issue

Closes #35

## Description

Adopt the Contributor Covenant v2.1 as the project's Code of Conduct.

- Add `CODE_OF_CONDUCT.md` (Contributor Covenant v2.1) at the repo root — the
  standard location GitHub surfaces in its community-health profile.
  Enforcement contact: dvoraj75@gmail.com.
- Transclude it into the docs site via a `pymdownx.snippets` page
  (`docs/development/code-of-conduct.md`) and add it to the MkDocs nav under
  Development, mirroring how `CHANGELOG.md` is already included.
- Cross-link it from `.github/CONTRIBUTING.md`, `docs/development/contributing.md`,
  and the README.
- Re-create the `## [Unreleased]` CHANGELOG section with the entry and tick the
  roadmap box.

Docs-only change — no Python touched. `mkdocs build --strict` passes.

## Checklist

- [x] This PR targets the `develop` branch
- [x] This PR is linked to an issue
- [x] Tests pass locally
