### PR TITLE
feat: actionable error hints (#34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Actionable error hints** (#34): `RLSTenantError` now accepts a keyword-only
+  `hint=` argument and exposes `.message` / `.hint` attributes for programmatic
+  access. The `NoTenantContextError` raised by `tenant_context()`,
+  `admin_context()`, `_resolve_user_guc_vars()`, the `@with_rls_context`
+  decorator, and `STRICT_MODE` now carries a `Hint:` line telling you exactly how
+  to fix it, and the `W001`/`W002`/`W008`/`W009` system-check hints name the exact
+  setting (and, for `W009`, the missing field). Backward compatible: `str(exc)` is
+  unchanged when no hint is supplied.
+
 - **Code of Conduct** (#35): adopted the Contributor Covenant v2.1
   (`CODE_OF_CONDUCT.md`), linked from the contributing guides and the
   documentation. Enforcement contact: dvoraj75@gmail.com.

--- a/django_rls_tenants/exceptions.py
+++ b/django_rls_tenants/exceptions.py
@@ -12,7 +12,26 @@ class RLSTenantError(Exception):
     """Base exception for all django-rls-tenants errors.
 
     Catch this to handle any error raised by the library.
+
+    Accepts an optional, keyword-only ``hint`` describing how to fix the
+    error. When supplied, it is appended to ``str(exc)`` after a blank line
+    and a ``Hint:`` label, so the suggestion shows up in tracebacks and
+    logs. The bare ``message`` and the ``hint`` are also exposed as
+    attributes for programmatic access.
+
+    Args:
+        message: Human-readable description of what went wrong.
+        hint: Optional actionable suggestion for fixing the error.
+
+    Attributes:
+        message: The error description, without the hint.
+        hint: The actionable suggestion, or ``None`` when not provided.
     """
+
+    def __init__(self, message: str, *, hint: str | None = None) -> None:
+        self.message = message
+        self.hint = hint
+        super().__init__(f"{message}\n\nHint: {hint}" if hint else message)
 
 
 class NoTenantContextError(RLSTenantError):

--- a/django_rls_tenants/tenants/checks.py
+++ b/django_rls_tenants/tenants/checks.py
@@ -116,8 +116,9 @@ def _check_guc_prefix_mismatch() -> list[CheckWarning]:
                         f"GUC_PREFIX derives {runtime_tenant_guc!r}. "
                         f"Tenant isolation will silently break.",
                         hint=(
-                            f"Either pass guc_tenant_var={runtime_tenant_guc!r} "
-                            f"to RLSConstraint or change GUC_PREFIX to match."
+                            f"Either pass guc_tenant_var={runtime_tenant_guc!r} to "
+                            f"the RLSConstraint, or set RLS_TENANTS['GUC_PREFIX'] so "
+                            f"it derives {runtime_tenant_guc!r}."
                         ),
                         id="django_rls_tenants.W001",
                     )
@@ -130,8 +131,9 @@ def _check_guc_prefix_mismatch() -> list[CheckWarning]:
                         f"GUC_PREFIX derives {runtime_admin_guc!r}. "
                         f"Admin bypass will silently break.",
                         hint=(
-                            f"Either pass guc_admin_var={runtime_admin_guc!r} "
-                            f"to RLSConstraint or change GUC_PREFIX to match."
+                            f"Either pass guc_admin_var={runtime_admin_guc!r} to "
+                            f"the RLSConstraint, or set RLS_TENANTS['GUC_PREFIX'] so "
+                            f"it derives {runtime_admin_guc!r}."
                         ),
                         id="django_rls_tenants.W002",
                     )
@@ -297,7 +299,8 @@ def _check_tenant_model_resolves() -> list[CheckWarning]:
                 f"RLS_TENANTS['TENANT_MODEL'] = {model_path!r} does not "
                 f"resolve to an installed model.",
                 hint=(
-                    "Set TENANT_MODEL to '<app_label>.<ModelName>' for a model in INSTALLED_APPS."
+                    "Set RLS_TENANTS['TENANT_MODEL'] to '<app_label>.<ModelName>' "
+                    "naming a model in INSTALLED_APPS."
                 ),
                 id="django_rls_tenants.W008",
             )
@@ -346,8 +349,9 @@ def _check_tenant_fk_field_exists() -> list[CheckWarning]:
                 CheckWarning(
                     f"{model.__name__} has no field {fk_field!r} referenced by its RLS policy.",
                     hint=(
-                        "Add the tenant ForeignKey, or set TENANT_FK_FIELD "
-                        "(or the constraint's field=) to the correct name."
+                        f"Add a {fk_field!r} ForeignKey to {model.__name__}, or "
+                        f"point RLS_TENANTS['TENANT_FK_FIELD'] (or the constraint's "
+                        f"field=) at an existing field."
                     ),
                     id="django_rls_tenants.W009",
                     obj=model,

--- a/django_rls_tenants/tenants/context.py
+++ b/django_rls_tenants/tenants/context.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar
 from django_rls_tenants.exceptions import NoTenantContextError
 from django_rls_tenants.rls.guc import clear_guc, get_guc, set_guc
 from django_rls_tenants.tenants.conf import rls_tenants_config
+from django_rls_tenants.tenants.errors import HINT_TENANT_ID_NONE, HINT_USER_NO_TENANT
 from django_rls_tenants.tenants.state import (
     reset_current_tenant_id,
     reset_rls_context_active,
@@ -64,12 +65,8 @@ def _resolve_user_guc_vars(
         }
     tenant_id = user.rls_tenant_id
     if tenant_id is None:
-        msg = (
-            f"Non-admin user has rls_tenant_id=None. "
-            f"Assign the user to a tenant or set is_tenant_admin=True. "
-            f"User type: {type(user).__name__}"
-        )
-        raise NoTenantContextError(msg)
+        msg = f"Non-admin user has rls_tenant_id=None (user type: {type(user).__name__})."
+        raise NoTenantContextError(msg, hint=HINT_USER_NO_TENANT)
     return {
         conf.GUC_IS_ADMIN: "false",
         conf.GUC_CURRENT_TENANT: str(tenant_id),
@@ -92,8 +89,8 @@ def tenant_context(
         NoTenantContextError: If ``tenant_id`` is ``None``.
     """
     if tenant_id is None:
-        msg = "tenant_id cannot be None. For admin access, use admin_context() instead."
-        raise NoTenantContextError(msg)
+        msg = "tenant_id cannot be None."
+        raise NoTenantContextError(msg, hint=HINT_TENANT_ID_NONE)
 
     conf = rls_tenants_config
     is_local = conf.USE_LOCAL_SET
@@ -251,12 +248,8 @@ def with_rls_context(
             elif as_user is not None:
                 tenant_id = as_user.rls_tenant_id
                 if tenant_id is None:
-                    msg = (
-                        f"Non-admin user passed to {fn.__qualname__} has "
-                        f"rls_tenant_id=None. Assign the user to a tenant "
-                        f"or set is_tenant_admin=True."
-                    )
-                    raise NoTenantContextError(msg)
+                    msg = f"Non-admin user passed to {fn.__qualname__} has rls_tenant_id=None."
+                    raise NoTenantContextError(msg, hint=HINT_USER_NO_TENANT)
                 ctx = tenant_context(tenant_id)
             else:
                 logger.warning(

--- a/django_rls_tenants/tenants/errors.py
+++ b/django_rls_tenants/tenants/errors.py
@@ -1,0 +1,38 @@
+"""Actionable hint constants for tenant-layer errors.
+
+These strings are passed as ``hint=`` to :class:`RLSTenantError` subclasses
+so every error tells the user how to fix it. They live in the ``tenants``
+layer (not ``exceptions.py``) because they name tenant-layer concepts --
+``tenant_context()``, ``admin_context()``, ``for_user()``, and the
+``TenantUser`` attributes -- which keeps :mod:`django_rls_tenants.exceptions`
+framework-agnostic.
+
+The same constants are reused wherever the library raises the matching
+condition (context managers, the ``@with_rls_context`` decorator, strict
+mode, and -- in later v1.3.0 features -- Celery tasks and the admin) so the
+guidance stays consistent.
+"""
+
+from __future__ import annotations
+
+HINT_NO_CONTEXT = (
+    "Establish an RLS context before the query: wrap it in "
+    "tenant_context(tenant_id) or admin_context(), scope the queryset with "
+    ".for_user(user), or enable RLSTenantMiddleware so each request sets the "
+    "context automatically."
+)
+"""No RLS context is active where one is required (e.g. strict mode)."""
+
+HINT_USER_NO_TENANT = (
+    "Assign the user to a tenant (set rls_tenant_id) or mark them as a "
+    "cross-tenant admin (is_tenant_admin=True). A non-admin TenantUser must "
+    "belong to exactly one tenant."
+)
+"""A non-admin ``TenantUser`` has ``rls_tenant_id=None``."""
+
+HINT_TENANT_ID_NONE = (
+    "Pass a concrete tenant primary key to tenant_context(tenant_id). For "
+    "cross-tenant admin access that bypasses tenant scoping, use "
+    "admin_context() instead."
+)
+"""``tenant_context(None)`` was called with no tenant id."""

--- a/django_rls_tenants/tenants/managers.py
+++ b/django_rls_tenants/tenants/managers.py
@@ -36,6 +36,7 @@ from django_rls_tenants.exceptions import NoTenantContextError
 from django_rls_tenants.rls.guc import clear_guc, set_guc
 from django_rls_tenants.tenants.conf import rls_tenants_config
 from django_rls_tenants.tenants.context import _resolve_user_guc_vars
+from django_rls_tenants.tenants.errors import HINT_NO_CONTEXT
 from django_rls_tenants.tenants.state import (
     get_current_tenant_id,
     get_rls_context_active,
@@ -257,14 +258,9 @@ class TenantQuerySet(models.QuerySet):  # type: ignore[type-arg]
         if self._rls_user is not None:
             return  # for_user() was called
         model_name = self.model.__name__
-        msg = (
-            f"RLS strict mode: query on {model_name} attempted without "
-            f"tenant context. Use tenant_context(), admin_context(), "
-            f"for_user(), or RLSTenantMiddleware before querying "
-            f"RLS-protected models. Set STRICT_MODE=False in RLS_TENANTS "
-            f"to disable this check."
-        )
-        raise NoTenantContextError(msg)
+        msg = f"RLS strict mode: query on {model_name} attempted without an active RLS context."
+        hint = f"{HINT_NO_CONTEXT} To disable this guard, set STRICT_MODE=False in RLS_TENANTS."
+        raise NoTenantContextError(msg, hint=hint)
 
     # ---- Guarded evaluation methods ----
     #

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -103,6 +103,22 @@ RLS_TENANTS = {
     mode adds an application-level check that raises before the query reaches
     the database.
 
+!!! tip "Actionable error hints"
+    The `NoTenantContextError` raised by strict mode -- and by `tenant_context()`,
+    `admin_context()`, and `@with_rls_context` -- carries a `Hint:` line telling you
+    how to establish a context. The bare message and the hint are also available
+    separately via the `.message` and `.hint` attributes:
+
+    ```python
+    from django_rls_tenants.exceptions import NoTenantContextError
+
+    try:
+        list(Order.objects.all())  # STRICT_MODE=True, no active context
+    except NoTenantContextError as exc:
+        log.error(exc.message)  # "RLS strict mode: query on Order attempted ..."
+        show_hint(exc.hint)     # "Establish an RLS context before the query: ..."
+    ```
+
 ### `TENANT_FK_FIELD`
 
 | | |

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from django_rls_tenants.exceptions import (
     NoTenantContextError,
     RLSConfigurationError,
@@ -63,3 +65,57 @@ class TestExceptionHierarchy:
         """RLSConfigurationError preserves the error message."""
         err = RLSConfigurationError("bad config")
         assert str(err) == "bad config"
+
+
+class TestErrorHints:
+    """Verify the optional, keyword-only hint mechanism on RLSTenantError."""
+
+    def test_no_hint_str_is_bare_message(self):
+        """Without a hint, str(exc) is exactly the message (backward compatible)."""
+        err = RLSTenantError("something broke")
+        assert str(err) == "something broke"
+
+    def test_hint_appended_to_str(self):
+        """With a hint, str(exc) appends a 'Hint:' line after a blank line."""
+        err = RLSTenantError("something broke", hint="turn it off and on")
+        assert str(err) == "something broke\n\nHint: turn it off and on"
+
+    def test_message_attribute_excludes_hint(self):
+        """The .message attribute holds the bare message, never the hint."""
+        err = RLSTenantError("bare", hint="fix it")
+        assert err.message == "bare"
+
+    def test_hint_attribute_exposes_hint(self):
+        """The .hint attribute exposes the hint for programmatic access."""
+        err = RLSTenantError("bare", hint="fix it")
+        assert err.hint == "fix it"
+
+    def test_hint_attribute_none_by_default(self):
+        """.hint is None and .message is set when no hint is supplied."""
+        err = RLSTenantError("bare")
+        assert err.hint is None
+        assert err.message == "bare"
+
+    def test_hint_is_keyword_only(self):
+        """hint must be passed by keyword, not positionally."""
+        with pytest.raises(TypeError):
+            RLSTenantError(*["bare", "fix it"])
+
+    def test_subclass_accepts_hint(self):
+        """Subclasses inherit the hint rendering and attributes."""
+        err = NoTenantContextError("no context", hint="wrap it")
+        assert err.message == "no context"
+        assert err.hint == "wrap it"
+        assert str(err) == "no context\n\nHint: wrap it"
+
+    def test_configuration_error_accepts_hint(self):
+        """RLSConfigurationError also inherits the hint behaviour."""
+        err = RLSConfigurationError("bad config", hint="set TENANT_MODEL")
+        assert err.hint == "set TENANT_MODEL"
+        assert "Hint: set TENANT_MODEL" in str(err)
+
+    def test_hinted_subclass_still_catchable_as_base(self):
+        """A hinted subclass is still catchable as RLSTenantError with its hint intact."""
+        with pytest.raises(RLSTenantError) as exc_info:
+            raise NoTenantContextError("x", hint="y")
+        assert exc_info.value.hint == "y"

--- a/tests/test_tenants/test_checks.py
+++ b/tests/test_tenants/test_checks.py
@@ -60,6 +60,8 @@ class TestCheckGucPrefixMismatch:
             warnings = _check_guc_prefix_mismatch()
         ids = [w.id for w in warnings]
         assert "django_rls_tenants.W001" in ids
+        w001 = next(w for w in warnings if w.id == "django_rls_tenants.W001")
+        assert "RLS_TENANTS['GUC_PREFIX']" in w001.hint
 
     def test_w002_admin_guc_mismatch(self):
         """W002 fires when GUC_PREFIX differs from RLSConstraint guc_admin_var."""
@@ -652,5 +654,7 @@ class TestCheckTenantFkFieldExists:
         with patch(self._RESOLVER_PATCH, return_value="nonexistent"):
             warnings = _check_tenant_fk_field_exists()
         assert "nonexistent" in warnings[0].msg
+        # The actionable hint also names the exact missing field.
+        assert "nonexistent" in warnings[0].hint
         assert warnings[0].obj is not None
         assert isinstance(warnings[0], CheckWarning)

--- a/tests/test_tenants/test_context.py
+++ b/tests/test_tenants/test_context.py
@@ -52,6 +52,14 @@ class TestTenantContext:
             with tenant_context(None):
                 pass
 
+    def test_none_error_carries_hint(self):
+        """tenant_context(None) attaches an actionable hint pointing to admin_context()."""
+        with pytest.raises(NoTenantContextError) as exc_info:  # noqa: SIM117
+            with tenant_context(None):
+                pass
+        assert exc_info.value.hint is not None
+        assert "admin_context()" in exc_info.value.hint
+
     def test_string_tenant_id(self):
         """Works with string tenant IDs (e.g., UUIDs)."""
         with tenant_context("abc-123"):
@@ -203,6 +211,16 @@ class TestResolveUserGucVars:
         with pytest.raises(NoTenantContextError, match="rls_tenant_id=None"):
             _resolve_user_guc_vars(user)
 
+    def test_non_admin_none_tenant_id_error_carries_hint(self):
+        """The error tells the user to assign a tenant or set is_tenant_admin=True."""
+        user = MagicMock()
+        user.is_tenant_admin = False
+        user.rls_tenant_id = None
+        with pytest.raises(NoTenantContextError) as exc_info:
+            _resolve_user_guc_vars(user)
+        assert exc_info.value.hint is not None
+        assert "is_tenant_admin=True" in exc_info.value.hint
+
     def test_admin_with_none_tenant_id_ok(self):
         """Admin user with rls_tenant_id=None is valid (admin bypasses RLS)."""
         user = MagicMock()
@@ -301,6 +319,21 @@ class TestWithRlsContext:
 
         with pytest.raises(NoTenantContextError, match="rls_tenant_id=None"):
             my_func(as_user=user)
+
+    def test_non_admin_none_tenant_id_error_carries_hint(self):
+        """The decorator's NoTenantContextError carries the assign-a-tenant hint."""
+        user = MagicMock()
+        user.is_tenant_admin = False
+        user.rls_tenant_id = None
+
+        @with_rls_context
+        def my_func(as_user):
+            return "should not reach"
+
+        with pytest.raises(NoTenantContextError) as exc_info:
+            my_func(as_user=user)
+        assert exc_info.value.hint is not None
+        assert "is_tenant_admin=True" in exc_info.value.hint
 
 
 class TestIsLocalMode:

--- a/tests/test_tenants/test_managers.py
+++ b/tests/test_tenants/test_managers.py
@@ -585,6 +585,19 @@ class TestStrictModeRaises:
         with pytest.raises(NoTenantContextError, match="Order"):
             list(qs)
 
+    @pytest.mark.usefixtures("_strict_mode")
+    def test_error_carries_actionable_hint(self, sample_orders):
+        """The bare message states the problem; .hint covers the fixes and STRICT_MODE."""
+        qs = Order.objects.all()
+        with pytest.raises(NoTenantContextError) as exc_info:
+            list(qs)
+        # The fix-it guidance moved out of the message into the hint.
+        assert exc_info.value.message.endswith("without an active RLS context.")
+        hint = exc_info.value.hint
+        assert hint is not None
+        assert "tenant_context(" in hint
+        assert "STRICT_MODE=False" in hint
+
 
 class TestStrictModeAllowsContext:
     """Tests that strict mode does NOT raise when context is properly set."""


### PR DESCRIPTION
## Summary

Implements issue #34 — actionable error messages with hints. Every
`NoTenantContextError` now tells the user how to fix it, and the system-check
hints name the exact setting and a copy-pasteable fix.

`RLSTenantError` gains an optional, **keyword-only** `hint=` argument and exposes
`.message` / `.hint` for programmatic access. Fully backward compatible:
`str(exc)` is unchanged when no hint is passed (audited — no internal code reads
`exc.args[0]`).

## What changed

- **New `tenants/errors.py`** — shared hint constants `HINT_NO_CONTEXT`,
  `HINT_USER_NO_TENANT`, `HINT_TENANT_ID_NONE`. Kept in the `tenants` layer
  (they name tenant-layer concepts), so `exceptions.py` stays
  framework-agnostic. These are reused by the upcoming #32 (Celery) and #31
  (admin) work.
- **`exceptions.py`** — `RLSTenantError.__init__(message, *, hint=None)` renders
  `"{message}\n\nHint: {hint}"` and stores `.message` / `.hint`.
- **`tenants/context.py`** — hints wired into all three raise sites
  (`tenant_context(None)`, `_resolve_user_guc_vars`, `with_rls_context`); the
  fix-it guidance moved out of the message into the hint.
- **`tenants/managers.py`** — the strict-mode error message now states only the
  problem; `.hint` carries how to establish context **plus** the
  `STRICT_MODE=False` escape hatch.
- **`tenants/checks.py`** — tightened `W001`/`W002`/`W008`/`W009` hints to name
  the exact `RLS_TENANTS[...]` setting and, for `W009`, the missing field name.

## Docs

- `getting-started/configuration.md` — the STRICT_MODE section documents the
  `Hint:` line and the `.hint` / `.message` attributes.
- `CHANGELOG.md` — re-created the `## [Unreleased]` section with the #34 entry
  (and restored the missing `[1.2.2]` compare link the release prep left behind).

## Tests & verification

- `test_exceptions.py` — new `TestErrorHints` (hint rendering, `.message` /
  `.hint` attributes, keyword-only enforcement, subclasses). Hint-substring
  assertions added across the context / managers / checks suites.
- `ruff check` ✓ · `ruff format --check` ✓ · `mypy django_rls_tenants` ✓
- `pytest` ✓ **499 passed**, coverage **92.21%** (gate 90%; `errors.py` 100%)
- `mkdocs build --strict` ✓

Closes #34
