### PR TITLE
feat: InitPlan-wrapped policy GUC reads (#57)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`CODE_OF_CONDUCT.md`), linked from the contributing guides and the
   documentation. Enforcement contact: dvoraj75@gmail.com.
 
+### Changed
+
+- **Performance: InitPlan-wrapped GUC reads** (#57): RLS policy predicates now
+  read PostgreSQL session variables through an uncorrelated scalar sub-SELECT
+  -- `(SELECT current_setting('rls.current_tenant', true))` -- so each GUC is
+  evaluated once per statement (a planner *InitPlan*) instead of once per row.
+  The predicate is otherwise unchanged, so query results are identical; the win
+  shows on large, admin, and raw-SQL scans. Applies to `RLSConstraint`,
+  `RLSM2MConstraint`, the `AddM2MRLSPolicy` migration operation, and the
+  `setup_m2m_rls` command (which also stops hardcoding `rls.is_admin` /
+  `rls.current_tenant` / `int` and instead derives the GUC names and tenant PK
+  cast from `RLS_TENANTS`). Existing policies are **not** rewritten
+  automatically -- see the migration guide ("From 1.2.2 to 1.3.0") to adopt the
+  new form.
+
 ## [1.2.2] - 2026-06-27
 
 ### Added

--- a/django_rls_tenants/management/commands/setup_m2m_rls.py
+++ b/django_rls_tenants/management/commands/setup_m2m_rls.py
@@ -9,11 +9,18 @@ from __future__ import annotations
 
 from typing import Any
 
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 from django.db import connections
 
 from django_rls_tenants.management.commands.check_rls import _collect_m2m_tables
-from django_rls_tenants.rls.constraints import _build_m2m_conditions, _build_m2m_create_sql
+from django_rls_tenants.rls.constraints import (
+    _build_m2m_conditions,
+    _build_m2m_create_sql,
+    _validate_guc_name_for_ddl,
+    _validate_pk_type,
+)
+from django_rls_tenants.rls.policy_sql import bool_flag_sql
+from django_rls_tenants.tenants.conf import RLSTenantsConfig
 
 
 class Command(BaseCommand):
@@ -55,6 +62,23 @@ class Command(BaseCommand):
             self.stdout.write("No M2M through tables found on RLS-protected models.")
             return
 
+        # Derive GUC names and the tenant PK cast from the live RLS_TENANTS
+        # settings instead of hardcoding "rls.*"/"int", so a custom GUC_PREFIX
+        # or TENANT_PK_TYPE is honoured. A fresh reader (not the cached
+        # module-level singleton) reflects settings overridden after startup.
+        conf = RLSTenantsConfig()
+
+        # These values flow straight into raw CREATE POLICY DDL. RLSConstraint
+        # and AddM2MRLSPolicy validate the equivalent arguments at construction;
+        # this command reads them from settings, so guard here too (a malformed
+        # GUC_PREFIX or TENANT_PK_TYPE otherwise surfaces as a cryptic SQL error).
+        try:
+            _validate_pk_type(conf.TENANT_PK_TYPE)
+            _validate_guc_name_for_ddl(conf.GUC_CURRENT_TENANT, "RLS_TENANTS['GUC_PREFIX']")
+            _validate_guc_name_for_ddl(conf.GUC_IS_ADMIN, "RLS_TENANTS['GUC_PREFIX']")
+        except ValueError as exc:
+            raise CommandError(str(exc)) from exc
+
         conn = connections[db_alias]
 
         # Check which tables already have policies
@@ -83,7 +107,7 @@ class Command(BaseCommand):
                 skipped += 1
                 continue
 
-            admin_check = "current_setting('rls.is_admin', true) = 'true'"
+            admin_check = bool_flag_sql(conf.GUC_IS_ADMIN)
             subquery_clause = _build_m2m_conditions(
                 from_fk=info["from_fk"],
                 from_table=info["from_table"],
@@ -91,8 +115,8 @@ class Command(BaseCommand):
                 to_fk=info["to_fk"],
                 to_table=info["to_table"],
                 to_tenant_fk=info["to_tenant_fk"],
-                guc_tenant_var="rls.current_tenant",
-                tenant_pk_type="int",
+                guc_tenant_var=conf.GUC_CURRENT_TENANT,
+                tenant_pk_type=conf.TENANT_PK_TYPE,
             )
             sql = _build_m2m_create_sql(
                 table=table, admin_check=admin_check, subquery_clause=subquery_clause

--- a/django_rls_tenants/operations.py
+++ b/django_rls_tenants/operations.py
@@ -19,6 +19,7 @@ from django_rls_tenants.rls.constraints import (
     _validate_model_path,
     _validate_pk_type,
 )
+from django_rls_tenants.rls.policy_sql import bool_flag_sql
 
 if TYPE_CHECKING:
     from django.db.backends.base.schema import BaseDatabaseSchemaEditor
@@ -115,7 +116,7 @@ class AddM2MRLSPolicy(migrations.operations.base.Operation):
     ) -> None:
         """Create the M2M RLS policy."""
         table = self.m2m_table
-        admin_check = f"current_setting('{self.guc_admin_var}', true) = 'true'"
+        admin_check = bool_flag_sql(self.guc_admin_var)
         subquery_clause = _build_m2m_conditions(
             from_fk=self.from_fk,
             from_table=self._resolve_table(self.from_model, to_state.apps),

--- a/django_rls_tenants/rls/constraints.py
+++ b/django_rls_tenants/rls/constraints.py
@@ -17,6 +17,7 @@ from django.db.backends.ddl_references import Statement
 from django.db.models import BaseConstraint
 
 from django_rls_tenants.rls.guc import _GUC_NAME_RE
+from django_rls_tenants.rls.policy_sql import bool_flag_sql, tenant_match_sql, tenant_value_sql
 
 if TYPE_CHECKING:
     from django.db.backends.base.schema import BaseDatabaseSchemaEditor
@@ -143,19 +144,15 @@ class RLSConstraint(BaseConstraint):
         table = model._meta.db_table  # type: ignore[union-attr]  # noqa: SLF001  -- Django's standard public API
         policy_name = f"{table}_tenant_isolation_policy"
 
-        tenant_match = (
-            f"{self.field}_id = nullif("
-            f"current_setting('{self.guc_tenant_var}', true), '')"
-            f"::{self.tenant_pk_type}"
+        tenant_match = tenant_match_sql(
+            f"{self.field}_id", self.guc_tenant_var, self.tenant_pk_type
         )
-        admin_check = f"current_setting('{self.guc_admin_var}', true) = 'true'"
+        admin_check = bool_flag_sql(self.guc_admin_var)
 
         # Build bypass conditions for CASE WHEN: admin is always first,
         # extra bypass flags are appended (USING only, NOT WITH CHECK).
         bypass_conditions_using = [admin_check]
-        bypass_conditions_using.extend(
-            f"current_setting('{flag}', true) = 'true'" for flag in self.extra_bypass_flags
-        )
+        bypass_conditions_using.extend(bool_flag_sql(flag) for flag in self.extra_bypass_flags)
 
         bypass_clause_using = "\n                              OR ".join(bypass_conditions_using)
         bypass_clause_check = admin_check  # only admin in WITH CHECK
@@ -311,7 +308,7 @@ def _build_m2m_conditions(
     which gives the PostgreSQL planner more optimisation flexibility
     than the equivalent ``IN (SELECT id ...)`` form.
     """
-    guc_expr = f"nullif(current_setting('{guc_tenant_var}', true), '')::{tenant_pk_type}"
+    guc_expr = tenant_value_sql(guc_tenant_var, tenant_pk_type)
     conditions: list[str] = []
 
     if from_tenant_fk is not None:
@@ -494,7 +491,7 @@ class RLSM2MConstraint(BaseConstraint):
     ) -> Statement:
         """Generate SQL to enable RLS and create the M2M isolation policy."""
         table = model._meta.db_table  # type: ignore[union-attr]  # noqa: SLF001
-        admin_check = f"current_setting('{self.guc_admin_var}', true) = 'true'"
+        admin_check = bool_flag_sql(self.guc_admin_var)
         subquery_clause = self._build_subquery_clause()
         return Statement(
             template="%(sql)s",

--- a/django_rls_tenants/rls/policy_sql.py
+++ b/django_rls_tenants/rls/policy_sql.py
@@ -1,0 +1,95 @@
+"""Single source of truth for RLS policy-predicate SQL fragments.
+
+Every RLS policy predicate reads PostgreSQL session variables (GUCs) with
+``current_setting()``.  These helpers build those fragments in one place so that
+``RLSConstraint`` / ``RLSM2MConstraint`` (this layer), the ``AddM2MRLSPolicy``
+migration operation, and the ``setup_m2m_rls`` command all emit byte-for-byte
+identical predicates.
+
+Each ``current_setting()`` read is wrapped in an uncorrelated scalar sub-SELECT,
+``(SELECT current_setting('<guc>', true))``.  PostgreSQL hoists such a sub-SELECT
+into a once-per-statement *InitPlan* instead of re-reading the GUC for every row
+scanned -- a free win on large, admin, and raw-SQL scans.  The predicate is
+otherwise unchanged, so query semantics are identical to the inline form.
+
+This module lives in the ``rls`` layer and imports nothing from ``tenants`` (a
+boundary enforced by ``tests/test_layering.py``).
+
+Safety:
+    These helpers perform string interpolation only; they add no escaping.
+    Callers must validate ``guc_var`` / ``column`` / ``tenant_pk_type`` against
+    the allowlists in :mod:`django_rls_tenants.rls.constraints` (GUC names against
+    ``_GUC_NAME_RE``, PK types against ``_ALLOWED_PK_TYPES``, columns against
+    ``_FIELD_NAME_RE``) before passing them here.
+"""
+
+from __future__ import annotations
+
+
+def scalar_setting(guc_var: str) -> str:
+    """Return ``(SELECT current_setting('<guc>', true))`` for ``guc_var``.
+
+    Wrapping the read in an uncorrelated scalar sub-SELECT lets PostgreSQL hoist
+    it into a once-per-statement InitPlan rather than evaluating ``current_setting``
+    per row.  The ``true`` (``missing_ok``) argument makes an unset GUC return an
+    empty string instead of raising.
+
+    Args:
+        guc_var: GUC variable name (e.g. ``"rls.current_tenant"``).
+
+    Returns:
+        The scalar sub-SELECT SQL fragment.
+    """
+    return f"(SELECT current_setting('{guc_var}', true))"
+
+
+def tenant_value_sql(guc_tenant_var: str, tenant_pk_type: str) -> str:
+    """Return the current-tenant GUC read, cast to the tenant PK type.
+
+    Produces ``nullif((SELECT current_setting('<guc>', true)), '')::<type>`` --
+    the right-hand side of the tenant equality, also usable on its own in an
+    ``INSERT`` / ``SELECT`` value list.  ``nullif(..., '')`` maps an unset GUC to
+    ``NULL`` so the cast never fails on an empty string.
+
+    Args:
+        guc_tenant_var: GUC variable holding the current tenant ID.
+        tenant_pk_type: SQL cast type for the tenant PK (e.g. ``"int"``).
+
+    Returns:
+        The cast tenant-value SQL fragment.
+    """
+    return f"nullif({scalar_setting(guc_tenant_var)}, '')::{tenant_pk_type}"
+
+
+def tenant_match_sql(column: str, guc_tenant_var: str, tenant_pk_type: str) -> str:
+    """Return a ``<column> = <current tenant>`` equality predicate.
+
+    Compares ``column`` against the current-tenant GUC cast to the tenant PK
+    type.  An unset GUC becomes ``NULL`` (via :func:`tenant_value_sql`), so the
+    equality yields ``NULL`` -- no rows match -- rather than a cast error.
+
+    Args:
+        column: Column reference to compare (e.g. ``"tenant_id"`` or a
+            table-qualified ``'"orders".tenant_id'``).
+        guc_tenant_var: GUC variable holding the current tenant ID.
+        tenant_pk_type: SQL cast type for the tenant PK (e.g. ``"int"``).
+
+    Returns:
+        The equality predicate SQL fragment.
+    """
+    return f"{column} = {tenant_value_sql(guc_tenant_var, tenant_pk_type)}"
+
+
+def bool_flag_sql(guc_var: str) -> str:
+    """Return a ``<guc> = 'true'`` boolean-flag predicate.
+
+    Used for the admin-bypass GUC and any extra bypass flags, each of which
+    holds the string ``"true"`` / ``"false"``.
+
+    Args:
+        guc_var: GUC variable holding a boolean flag (e.g. ``"rls.is_admin"``).
+
+    Returns:
+        The boolean-flag predicate SQL fragment.
+    """
+    return f"{scalar_setting(guc_var)} = 'true'"

--- a/docs/advanced/architecture.md
+++ b/docs/advanced/architecture.md
@@ -99,17 +99,17 @@ ALTER TABLE "myapp_order" FORCE ROW LEVEL SECURITY;
 CREATE POLICY "myapp_order_tenant_isolation_policy"
 ON "myapp_order"
 USING (
-    CASE WHEN current_setting('rls.is_admin', true) = 'true'
+    CASE WHEN (SELECT current_setting('rls.is_admin', true)) = 'true'
          THEN true
          ELSE tenant_id = nullif(
-             current_setting('rls.current_tenant', true), '')::int
+             (SELECT current_setting('rls.current_tenant', true)), '')::int
     END
 )
 WITH CHECK (
-    CASE WHEN current_setting('rls.is_admin', true) = 'true'
+    CASE WHEN (SELECT current_setting('rls.is_admin', true)) = 'true'
          THEN true
          ELSE tenant_id = nullif(
-             current_setting('rls.current_tenant', true), '')::int
+             (SELECT current_setting('rls.current_tenant', true)), '')::int
     END
 );
 ```
@@ -119,10 +119,12 @@ Key design decisions in the policy:
 - **`CASE WHEN ... THEN true ELSE ...`**: the `CASE` structure clearly separates
   admin bypass from tenant matching. For admin queries the tenant check is skipped.
   For normal tenant queries the expression reduces to a simple `tenant_id = <value>`
-  equality. Note: since ``current_setting()`` is ``VOLATILE``, both ``CASE WHEN`` and
-  ``OR``-based policies have equivalent per-row evaluation cost. The primary
-  performance benefit comes from auto-scoping (``WHERE tenant_id = X`` in
-  ``get_queryset()``), which enables composite index usage.
+  equality. Since v1.3.0 each ``current_setting()`` read is wrapped in an
+  uncorrelated scalar sub-SELECT -- ``(SELECT current_setting('rls.current_tenant',
+  true))`` -- which PostgreSQL evaluates once per statement (an InitPlan) instead
+  of per row; the predicate is otherwise identical. The larger performance benefit
+  still comes from auto-scoping (``WHERE tenant_id = X`` in ``get_queryset()``),
+  which enables composite index usage.
 - **`current_setting(..., true)`**: the `true` parameter returns empty string instead
   of raising an error when the GUC is not set. This enables fail-closed behavior.
 - **`nullif(..., '')`**: converts empty string to `NULL`, making the
@@ -142,16 +144,16 @@ through tables have no tenant FK column:
 CREATE POLICY "myapp_project_members_m2m_rls_policy"
 ON "myapp_project_members"
 USING (
-    CASE WHEN current_setting('rls.is_admin', true) = 'true'
+    CASE WHEN (SELECT current_setting('rls.is_admin', true)) = 'true'
          THEN true
          ELSE EXISTS (SELECT 1 FROM "myapp_project"
                       WHERE id = project_id
                       AND tenant_id = nullif(
-                          current_setting('rls.current_tenant', true), '')::int)
+                          (SELECT current_setting('rls.current_tenant', true)), '')::int)
               AND EXISTS (SELECT 1 FROM "myapp_user"
                           WHERE id = user_id
                           AND tenant_id = nullif(
-                              current_setting('rls.current_tenant', true), '')::int)
+                              (SELECT current_setting('rls.current_tenant', true)), '')::int)
     END
 )
 WITH CHECK (...same...);

--- a/docs/advanced/migration-guide.md
+++ b/docs/advanced/migration-guide.md
@@ -123,6 +123,60 @@ migration that assigns the correct tenant to each existing record.
 
 ## Upgrading django-rls-tenants
 
+### From 1.2.2 to 1.3.0
+
+A **drop-in upgrade** -- no code changes are required and runtime behaviour is
+unchanged. The release is additive, with one optional, opt-in performance step.
+
+#### Optional: adopt the InitPlan policy form (#57)
+
+v1.3.0 wraps every GUC read in a policy predicate in an uncorrelated scalar
+sub-SELECT -- `(SELECT current_setting('rls.current_tenant', true))` -- so
+PostgreSQL evaluates the variable **once per statement** (a planner *InitPlan*)
+instead of once per row. The predicate is otherwise identical, so query results
+never change; the benefit shows on large, admin, and raw-SQL scans.
+
+Because `RLSConstraint` / `RLSM2MConstraint` serialize identically
+(`deconstruct()` is unchanged), Django generates **no new migration**, and the
+`CREATE POLICY ... IF NOT EXISTS` guard **skips tables that already have a
+policy**. So *new* deployments get the InitPlan form automatically, while
+*existing* policies keep the previous inline form until you drop and recreate
+them. Adopting it on a running database is optional and can be done
+table-by-table.
+
+**M2M through tables** -- drop the policy, then re-run `setup_m2m_rls`, which
+recreates a policy only on tables that don't have one:
+
+```sql
+DROP POLICY IF EXISTS "<through_table>_m2m_rls_policy" ON "<through_table>";
+```
+
+```bash
+python manage.py setup_m2m_rls         # recreates the dropped policy (InitPlan form)
+python manage.py check_rls --verbose   # confirm the live USING / WITH CHECK
+```
+
+**Standard tenant tables** -- recreate the policy through the migration that
+defines the `RLSConstraint`. Reversing that migration runs the constraint's
+`remove_sql` (drops the policy and disables RLS); re-applying runs `create_sql`,
+which now emits the v1.3.0 InitPlan SQL:
+
+```bash
+python manage.py migrate <app> <migration_before_the_RLSConstraint>     # drops the old policy
+python manage.py migrate <app> <migration_that_adds_the_RLSConstraint>  # recreates it
+```
+
+!!! warning
+    Reversing the migration briefly **disables RLS** on that table. Run it inside
+    a maintenance window, or instead drop and recreate the single policy with
+    explicit SQL in one transaction. Always confirm with
+    `python manage.py check_rls --verbose`, which prints the live `USING` /
+    `WITH CHECK` so you can verify the `(SELECT current_setting(...))` form is in
+    place.
+
+Policy names follow `"{table}_tenant_isolation_policy"` (standard models) and
+`"{through_table}_m2m_rls_policy"` (M2M join tables).
+
 ### From 1.2.1 to 1.2.2
 
 A **drop-in upgrade** -- no breaking changes, and no code or data migration is

--- a/docs/advanced/security.md
+++ b/docs/advanced/security.md
@@ -19,6 +19,11 @@ END
 -- tenant_id = NULL → always false → zero rows
 ```
 
+Since v1.3.0 each `current_setting()` read in a policy is wrapped in a scalar
+sub-SELECT -- `(SELECT current_setting(...))` -- so PostgreSQL evaluates it once
+per statement (an InitPlan) rather than per row. This is purely a planner
+optimization: the fail-closed semantics shown above are identical.
+
 This means:
 
 - Unauthenticated requests see zero rows (middleware does not set GUCs).

--- a/docs/guides/management-commands.md
+++ b/docs/guides/management-commands.md
@@ -96,13 +96,13 @@ takes precedence, so verbose detail only appears on a non-quiet run.
     myapp_order_tenant_isolation_policy [ALL]
       USING:
         CASE
-            WHEN (current_setting('rls.is_admin'::text, true) = 'true'::text) THEN true
-            ELSE (tenant_id = (NULLIF(current_setting('rls.current_tenant'::text, true), ''::text))::integer)
+            WHEN (( SELECT current_setting('rls.is_admin'::text, true) AS current_setting) = 'true'::text) THEN true
+            ELSE (tenant_id = (NULLIF(( SELECT current_setting('rls.current_tenant'::text, true) AS current_setting), ''::text))::integer)
         END
       WITH CHECK:
         CASE
-            WHEN (current_setting('rls.is_admin'::text, true) = 'true'::text) THEN true
-            ELSE (tenant_id = (NULLIF(current_setting('rls.current_tenant'::text, true), ''::text))::integer)
+            WHEN (( SELECT current_setting('rls.is_admin'::text, true) AS current_setting) = 'true'::text) THEN true
+            ELSE (tenant_id = (NULLIF(( SELECT current_setting('rls.current_tenant'::text, true) AS current_setting), ''::text))::integer)
         END
 ```
 

--- a/docs/guides/protecting-models.md
+++ b/docs/guides/protecting-models.md
@@ -37,17 +37,17 @@ ALTER TABLE "myapp_order" FORCE ROW LEVEL SECURITY;
 CREATE POLICY "myapp_order_tenant_isolation_policy"
 ON "myapp_order"
 USING (
-    CASE WHEN current_setting('rls.is_admin', true) = 'true'
+    CASE WHEN (SELECT current_setting('rls.is_admin', true)) = 'true'
          THEN true
          ELSE tenant_id = nullif(
-             current_setting('rls.current_tenant', true), '')::int
+             (SELECT current_setting('rls.current_tenant', true)), '')::int
     END
 )
 WITH CHECK (
-    CASE WHEN current_setting('rls.is_admin', true) = 'true'
+    CASE WHEN (SELECT current_setting('rls.is_admin', true)) = 'true'
          THEN true
          ELSE tenant_id = nullif(
-             current_setting('rls.current_tenant', true), '')::int
+             (SELECT current_setting('rls.current_tenant', true)), '')::int
     END
 );
 ```

--- a/docs/why-rls.md
+++ b/docs/why-rls.md
@@ -58,17 +58,17 @@ The SQL behind this is straightforward:
 ```sql
 CREATE POLICY "orders_tenant_isolation_policy" ON "orders"
     USING (
-        CASE WHEN current_setting('rls.is_admin', true) = 'true'
+        CASE WHEN (SELECT current_setting('rls.is_admin', true)) = 'true'
              THEN true
              ELSE tenant_id = nullif(
-                 current_setting('rls.current_tenant', true), '')::int
+                 (SELECT current_setting('rls.current_tenant', true)), '')::int
         END
     )
     WITH CHECK (
-        CASE WHEN current_setting('rls.is_admin', true) = 'true'
+        CASE WHEN (SELECT current_setting('rls.is_admin', true)) = 'true'
              THEN true
              ELSE tenant_id = nullif(
-                 current_setting('rls.current_tenant', true), '')::int
+                 (SELECT current_setting('rls.current_tenant', true)), '')::int
         END
     );
 ```

--- a/tests/test_integration/test_setup_m2m_rls.py
+++ b/tests/test_integration/test_setup_m2m_rls.py
@@ -6,7 +6,9 @@ from io import StringIO
 
 import pytest
 from django.core.management import call_command
+from django.core.management.base import CommandError
 from django.db import connection
+from django.test import override_settings
 
 from django_rls_tenants.management.commands.check_rls import _collect_m2m_tables
 from django_rls_tenants.rls.constraints import _build_m2m_drop_sql
@@ -135,3 +137,60 @@ class TestSetupM2MRlsCommand:
         # ...and the policy is never created.
         assert "policy applied" not in output
         assert not _m2m_policy_exists(table)
+
+    @override_settings(
+        RLS_TENANTS={
+            "TENANT_MODEL": "test_app.Tenant",
+            "GUC_PREFIX": "myco",
+            "TENANT_FK_FIELD": "tenant",
+            "TENANT_PK_TYPE": "int",
+        }
+    )
+    def test_guc_names_derived_from_settings(self):
+        """GUC names come from RLS_TENANTS, not hardcoded rls.* / int (#57).
+
+        Pre-#57 the command hardcoded ``rls.is_admin`` / ``rls.current_tenant`` /
+        ``int``; with ``GUC_PREFIX='myco'`` the emitted SQL must use the
+        ``myco.*`` names, and each read must be InitPlan-wrapped.
+        """
+        _unprotect_one_m2m_table()  # force the apply/print path
+
+        out = StringIO()
+        call_command("setup_m2m_rls", "--dry-run", stdout=out)
+        output = out.getvalue()
+
+        # GUC names honour the configured prefix, InitPlan-wrapped...
+        assert "(SELECT current_setting('myco.is_admin', true)) = 'true'" in output
+        assert "(SELECT current_setting('myco.current_tenant', true))" in output
+        # ...and the previously hardcoded rls.* GUC names are gone.
+        assert "rls.is_admin" not in output
+        assert "rls.current_tenant" not in output
+        # InitPlan form, not the pre-#57 inline read.
+        assert "nullif(current_setting(" not in output
+
+    @override_settings(
+        RLS_TENANTS={
+            "TENANT_MODEL": "test_app.Tenant",
+            "TENANT_PK_TYPE": "text",  # not in the {int, bigint, uuid} allowlist
+        }
+    )
+    def test_invalid_tenant_pk_type_rejected(self):
+        """A bad TENANT_PK_TYPE is rejected before it reaches raw DDL (#57).
+
+        The command interpolates ``TENANT_PK_TYPE`` into a ``::<type>`` cast and
+        reads it straight from settings, so an out-of-allowlist value must raise
+        a clean ``CommandError`` instead of emitting invalid policy SQL.
+        """
+        with pytest.raises(CommandError, match="Invalid tenant_pk_type"):
+            call_command("setup_m2m_rls", "--dry-run", stdout=StringIO())
+
+    @override_settings(
+        RLS_TENANTS={
+            "TENANT_MODEL": "test_app.Tenant",
+            "GUC_PREFIX": "bad prefix",  # space is not a valid GUC-name character
+        }
+    )
+    def test_invalid_guc_prefix_rejected(self):
+        """A malformed GUC_PREFIX is rejected before it reaches raw DDL (#57)."""
+        with pytest.raises(CommandError, match="Invalid GUC name"):
+            call_command("setup_m2m_rls", "--dry-run", stdout=StringIO())

--- a/tests/test_rls/test_constraints.py
+++ b/tests/test_rls/test_constraints.py
@@ -561,3 +561,85 @@ class TestM2MInputValidation:
         c = _make_m2m_constraint(to_tenant_fk=None)
         assert c.to_tenant_fk is None
         assert c.from_tenant_fk == "tenant"
+
+
+# ===========================================================================
+# Issue #57 -- InitPlan-wrapped GUC reads
+# ===========================================================================
+
+
+class TestInitPlanWrapping:
+    """RLSConstraint reads each policy GUC via (SELECT current_setting(...)).
+
+    The scalar sub-SELECT lets PostgreSQL evaluate the GUC once per statement
+    (InitPlan) instead of per row. Semantics are unchanged.
+    """
+
+    def test_admin_check_wrapped(self):
+        c = RLSConstraint(field="tenant", name="test_rls")
+        sql = _get_create_sql(c)
+        assert "(SELECT current_setting('rls.is_admin', true)) = 'true'" in sql
+
+    def test_tenant_match_wrapped(self):
+        c = RLSConstraint(field="tenant", name="test_rls")
+        sql = _get_create_sql(c)
+        assert (
+            "tenant_id = nullif((SELECT current_setting('rls.current_tenant', true)), '')::int"
+            in sql
+        )
+
+    def test_extra_bypass_flag_wrapped(self):
+        c = RLSConstraint(
+            field="tenant", name="test_rls", extra_bypass_flags=["rls.is_login_request"]
+        )
+        sql = _get_create_sql(c)
+        assert "(SELECT current_setting('rls.is_login_request', true)) = 'true'" in sql
+
+    def test_custom_guc_and_uuid_pk_wrapped(self):
+        c = RLSConstraint(
+            field="org",
+            name="test_rls",
+            guc_tenant_var="myco.current_tenant",
+            guc_admin_var="myco.is_admin",
+            tenant_pk_type="uuid",
+        )
+        sql = _get_create_sql(c)
+        assert (
+            "org_id = nullif((SELECT current_setting('myco.current_tenant', true)), '')::uuid"
+            in sql
+        )
+        assert "(SELECT current_setting('myco.is_admin', true)) = 'true'" in sql
+
+    def test_no_unwrapped_current_setting(self):
+        """Regression guard: none of the pre-#57 inline forms remain."""
+        c = RLSConstraint(
+            field="tenant", name="test_rls", extra_bypass_flags=["rls.is_login_request"]
+        )
+        sql = _get_create_sql(c)
+        assert "nullif(current_setting(" not in sql
+        assert "current_setting('rls.is_admin', true) = 'true'" not in sql
+        assert "current_setting('rls.is_login_request', true) = 'true'" not in sql
+
+
+class TestM2MInitPlanWrapping:
+    """RLSM2MConstraint wraps its GUC reads in scalar sub-SELECTs too (#57)."""
+
+    def test_admin_check_wrapped(self):
+        c = _make_m2m_constraint()
+        sql = _get_m2m_create_sql(c)
+        assert "(SELECT current_setting('rls.is_admin', true)) = 'true'" in sql
+
+    def test_tenant_value_wrapped(self):
+        c = _make_m2m_constraint()
+        sql = _get_m2m_create_sql(c)
+        assert (
+            "tenant_id = nullif((SELECT current_setting('rls.current_tenant', true)), '')::int"
+            in sql
+        )
+
+    def test_no_unwrapped_current_setting(self):
+        """Regression guard: none of the pre-#57 inline forms remain."""
+        c = _make_m2m_constraint()
+        sql = _get_m2m_create_sql(c)
+        assert "nullif(current_setting(" not in sql
+        assert "current_setting('rls.is_admin', true) = 'true'" not in sql

--- a/tests/test_rls/test_m2m_operations.py
+++ b/tests/test_rls/test_m2m_operations.py
@@ -181,3 +181,41 @@ class TestAddM2MRLSPolicyStateForwards:
             to_fk="d_id",
         )
         assert op.reversible is True
+
+
+class TestAddM2MRLSPolicyInitPlanWrapping:
+    """Issue #57: database_forwards emits InitPlan-wrapped GUC reads."""
+
+    def _forwards_sql(self) -> str:
+        op = AddM2MRLSPolicy(
+            m2m_table="myapp_project_users",
+            from_model="myapp.Project",
+            to_model="myapp.User",
+            from_fk="project_id",
+            to_fk="user_id",
+        )
+        schema_editor = MagicMock()
+        to_state = MagicMock()
+        to_state.apps = _make_mock_apps(
+            ("myapp.Project", "myapp_project"),
+            ("myapp.User", "myapp_user"),
+        )
+        op.database_forwards("myapp", schema_editor, MagicMock(), to_state)
+        return schema_editor.execute.call_args[0][0]
+
+    def test_admin_check_wrapped(self):
+        sql = self._forwards_sql()
+        assert "(SELECT current_setting('rls.is_admin', true)) = 'true'" in sql
+
+    def test_tenant_value_wrapped(self):
+        sql = self._forwards_sql()
+        assert (
+            "tenant_id = nullif((SELECT current_setting('rls.current_tenant', true)), '')::int"
+            in sql
+        )
+
+    def test_no_unwrapped_current_setting(self):
+        """Regression guard: none of the pre-#57 inline forms remain."""
+        sql = self._forwards_sql()
+        assert "nullif(current_setting(" not in sql
+        assert "current_setting('rls.is_admin', true) = 'true'" not in sql

--- a/tests/test_rls/test_policy_sql.py
+++ b/tests/test_rls/test_policy_sql.py
@@ -1,0 +1,86 @@
+"""Tests for django_rls_tenants.rls.policy_sql.
+
+These cover the InitPlan-wrapping helpers (issue #57): every GUC read is wrapped
+in an uncorrelated scalar sub-SELECT, ``(SELECT current_setting('<guc>', true))``,
+so PostgreSQL evaluates it once per statement instead of per row.
+"""
+
+from __future__ import annotations
+
+from django_rls_tenants.rls.policy_sql import (
+    bool_flag_sql,
+    scalar_setting,
+    tenant_match_sql,
+    tenant_value_sql,
+)
+
+
+class TestScalarSetting:
+    """Tests for scalar_setting()."""
+
+    def test_wraps_current_setting_in_subselect(self):
+        assert scalar_setting("rls.current_tenant") == (
+            "(SELECT current_setting('rls.current_tenant', true))"
+        )
+
+    def test_custom_guc_name(self):
+        assert scalar_setting("myco.is_admin") == (
+            "(SELECT current_setting('myco.is_admin', true))"
+        )
+
+
+class TestTenantValueSql:
+    """Tests for tenant_value_sql()."""
+
+    def test_int_pk(self):
+        assert tenant_value_sql("rls.current_tenant", "int") == (
+            "nullif((SELECT current_setting('rls.current_tenant', true)), '')::int"
+        )
+
+    def test_uuid_pk(self):
+        assert tenant_value_sql("rls.current_tenant", "uuid") == (
+            "nullif((SELECT current_setting('rls.current_tenant', true)), '')::uuid"
+        )
+
+    def test_read_is_wrapped_not_inline(self):
+        sql = tenant_value_sql("rls.current_tenant", "int")
+        # The InitPlan win: current_setting lives inside a scalar sub-SELECT.
+        assert "(SELECT current_setting(" in sql
+        # The pre-#57 inline form must be gone.
+        assert "nullif(current_setting(" not in sql
+
+
+class TestTenantMatchSql:
+    """Tests for tenant_match_sql()."""
+
+    def test_default(self):
+        assert tenant_match_sql("tenant_id", "rls.current_tenant", "int") == (
+            "tenant_id = nullif((SELECT current_setting('rls.current_tenant', true)), '')::int"
+        )
+
+    def test_table_qualified_column(self):
+        sql = tenant_match_sql('"orders".tenant_id', "rls.current_tenant", "int")
+        assert sql.startswith('"orders".tenant_id = ')
+
+    def test_is_column_equals_tenant_value(self):
+        # tenant_match_sql is exactly "<column> = <tenant_value_sql(...)>".
+        col, guc, pk = "tenant_id", "rls.current_tenant", "int"
+        assert tenant_match_sql(col, guc, pk) == f"{col} = {tenant_value_sql(guc, pk)}"
+
+
+class TestBoolFlagSql:
+    """Tests for bool_flag_sql()."""
+
+    def test_default(self):
+        assert bool_flag_sql("rls.is_admin") == (
+            "(SELECT current_setting('rls.is_admin', true)) = 'true'"
+        )
+
+    def test_custom_flag(self):
+        assert bool_flag_sql("rls.is_login_request") == (
+            "(SELECT current_setting('rls.is_login_request', true)) = 'true'"
+        )
+
+    def test_read_is_wrapped_not_inline(self):
+        # The pre-#57 inline form ("current_setting('x', true) = 'true'") is gone.
+        assert bool_flag_sql("rls.is_admin").startswith("(SELECT current_setting(")


### PR DESCRIPTION
Closes #57

## Summary

Wraps every RLS policy-predicate `current_setting()` read in an uncorrelated scalar sub-SELECT — `(SELECT current_setting('<guc>', true))` — so PostgreSQL evaluates each GUC **once per statement** (a planner *InitPlan*) instead of once per row. The predicate is otherwise identical, so query semantics are unchanged; the win shows on large, admin, and raw-SQL scans.

- **`rls/policy_sql.py`** (new): single source of truth for the four predicate fragments (`scalar_setting`, `tenant_value_sql`, `tenant_match_sql`, `bool_flag_sql`). Lives in the `rls` layer with zero `tenants/` imports.
- `RLSConstraint`, `RLSM2MConstraint`, and the `AddM2MRLSPolicy` operation build their `USING` / `WITH CHECK` predicates through these helpers.
- `setup_m2m_rls` derives the GUC names + tenant PK cast from `RLS_TENANTS` (via a fresh `RLSTenantsConfig`) instead of hardcoding `rls.*` / `int`.

`deconstruct()` / `__eq__` are unchanged, so Django generates **no migration** and the `IF NOT EXISTS` guard skips existing policies — only newly-created policies get the InitPlan form. The migration guide documents the drop+recreate recipe.

## Verified against live PostgreSQL

- ✅ The wrapped policy **creates successfully**; the existing end-to-end isolation suite (ORM + raw SQL) passes against the new form, confirming identical semantics.
- ✅ `EXPLAIN` confirms the optimization: the wrapped reads become `InitPlan 1/2 (returns $0/$1)`, and the per-row `Filter` references `$0`/`$1` rather than calling `current_setting` per row.

## Post-review hardening (folded into this PR)

A deep review of the original commit surfaced three items, all addressed here:

- **Docstring accuracy** — `policy_sql.py` referenced nonexistent "`tenants` raw-SQL helpers" (the `tenants` layer filters via the ORM, not raw SQL). Corrected to the real callers.
- **Validation gap** — moving `setup_m2m_rls` from hardcoded-safe values to settings-derived `GUC_PREFIX` / `TENANT_PK_TYPE` opened an unvalidated path into raw DDL (unlike `RLSConstraint` / `AddM2MRLSPolicy`, which validate). Added `_validate_pk_type` / `_validate_guc_name_for_ddl` guards raising a clean `CommandError`, + 2 tests.
- **Stale docs** — the generated-SQL examples in `architecture.md` / `protecting-models.md` / `why-rls.md` and the `check_rls --verbose` sample in `management-commands.md` still showed the pre-#57 inline form (and `architecture.md` contradicted its own v1.3.0 note). Synced to the wrapped form; the `--verbose` sample matches the live `pg_get_expr()` rendering. `security.md` intentionally keeps the simplified form with an explanatory note.

## Checks

- `pytest`: **524 passed**, 92% coverage
- `ruff check` / `ruff format --check` / `mypy`: clean
- `uv lock --check`: clean
- `mkdocs build --strict`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
