### PR TITLE
feat: add safe_tenant_sql() raw-SQL helper (#33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`CODE_OF_CONDUCT.md`), linked from the contributing guides and the
   documentation. Enforcement contact: dvoraj75@gmail.com.
 
+- **Raw SQL helper `safe_tenant_sql()`** (#33): a `WHERE`-clause fragment that
+  scopes raw queries to the current tenant using the same `current_setting()`
+  expression as the RLS policies (including the #57 InitPlan form); the GUC
+  names and the tenant PK cast come from `RLS_TENANTS`. Supports the same
+  `extra_bypass_flags` as `RLSConstraint`, so the fragment can mirror a policy's
+  full bypass set. Adds a companion `current_tenant_value_sql()` for `INSERT` /
+  `SELECT` value lists. Both contain no bind parameters (the tenant id is read
+  in-database from the session GUC), validate every interpolated identifier, are
+  re-exported from the top-level package, and are documented in the new Raw SQL
+  guide.
+
 ### Changed
 
 - **Performance: InitPlan-wrapped GUC reads** (#57): RLS policy predicates now

--- a/django_rls_tenants/__init__.py
+++ b/django_rls_tenants/__init__.py
@@ -22,6 +22,8 @@ __all__ = [
     "TenantUser",
     "__version__",
     "admin_context",
+    "current_tenant_value_sql",
+    "safe_tenant_sql",
     "tenant_context",
     "with_rls_context",
 ]
@@ -36,6 +38,8 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "TenantQuerySet": ("django_rls_tenants.tenants.managers", "TenantQuerySet"),
     "TenantUser": ("django_rls_tenants.tenants.types", "TenantUser"),
     "admin_context": ("django_rls_tenants.tenants.context", "admin_context"),
+    "current_tenant_value_sql": ("django_rls_tenants.tenants.sql", "current_tenant_value_sql"),
+    "safe_tenant_sql": ("django_rls_tenants.tenants.sql", "safe_tenant_sql"),
     "tenant_context": ("django_rls_tenants.tenants.context", "tenant_context"),
     "with_rls_context": ("django_rls_tenants.tenants.context", "with_rls_context"),
 }

--- a/django_rls_tenants/rls/constraints.py
+++ b/django_rls_tenants/rls/constraints.py
@@ -27,7 +27,9 @@ if TYPE_CHECKING:
 _ALLOWED_PK_TYPES = frozenset({"int", "bigint", "uuid"})
 
 # Valid SQL identifier for field names (no dots, just a column name).
-_FIELD_NAME_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+# ``\Z`` (not ``$``) anchors the end: ``$`` also matches just before a trailing
+# newline, which would let "tenant_id\n" slip through.
+_FIELD_NAME_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*\Z")
 
 
 def _validate_field_name(field: str, param: str = "field") -> None:

--- a/django_rls_tenants/rls/guc.py
+++ b/django_rls_tenants/rls/guc.py
@@ -11,7 +11,9 @@ import re
 from django.db import connections
 
 # Valid GUC names: dotted identifiers like "rls.current_tenant" or "myapp.is_admin".
-_GUC_NAME_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_.]*$")
+# ``\Z`` (not ``$``) anchors the end: ``$`` also matches just before a trailing
+# newline, which would let "rls.x\n" slip through.
+_GUC_NAME_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_.]*\Z")
 
 
 def _validate_guc_name(name: str) -> None:

--- a/django_rls_tenants/tenants/sql.py
+++ b/django_rls_tenants/tenants/sql.py
@@ -1,0 +1,189 @@
+"""Safe raw-SQL helpers for scoping queries to the current tenant.
+
+Sometimes the ORM is not enough -- a hand-written report, a bulk ``UPDATE``, or
+a query against a view -- yet the query must still respect tenant isolation.
+RLS already enforces isolation at the database level, but adding the *same*
+predicate to a raw query makes the intent explicit, lets the planner use a
+tenant index, and keeps admin-bypass behaviour identical to the live policies.
+
+:func:`safe_tenant_sql` returns a ``WHERE``-clause fragment and
+:func:`current_tenant_value_sql` returns the current-tenant value expression.
+Both are built from the exact same :mod:`~django_rls_tenants.rls.policy_sql`
+helpers the RLS policies use, so the predicate they apply is *semantically
+identical* to what PostgreSQL enforces.  (The bare tenant match is byte-for-byte
+the policy's; the admin-inclusive form is ``(<match> OR <admin>)`` rather than
+the policy's ``CASE WHEN <admin> THEN true ELSE <match> END`` -- a different
+spelling of the same truth table, not a different result.)
+
+Safety:
+    The returned fragments contain **no bind parameters**.  The tenant id is read
+    *inside PostgreSQL* from the session GUC (set by ``tenant_context()`` /
+    middleware), so the fragment carries zero Python-side user input.  Every
+    identifier interpolated into the fragment -- the column, the optional table,
+    the GUC names, and the PK cast type -- is validated against the same
+    allowlists the RLS constraints use; an invalid identifier raises
+    ``ValueError`` rather than producing injectable SQL.
+
+Example:
+    >>> from django_rls_tenants import safe_tenant_sql, tenant_context
+    >>> from django.db import connection
+    >>> with tenant_context(tenant.pk), connection.cursor() as cursor:
+    ...     cursor.execute(
+    ...         f"SELECT product, amount FROM orders WHERE {safe_tenant_sql()} "
+    ...         f"AND amount > %s",
+    ...         [100],
+    ...     )
+    ...     rows = cursor.fetchall()
+"""
+
+from __future__ import annotations
+
+from django_rls_tenants.rls.constraints import _validate_field_name, _validate_pk_type
+from django_rls_tenants.rls.guc import _validate_guc_name
+from django_rls_tenants.rls.policy_sql import bool_flag_sql, tenant_match_sql, tenant_value_sql
+from django_rls_tenants.tenants.conf import rls_tenants_config
+
+
+def _validated_tenant_guc_and_pk_type() -> tuple[str, str]:
+    """Return the validated current-tenant GUC name and tenant PK cast type.
+
+    Reads both from ``RLS_TENANTS`` and validates them against the same
+    allowlists the RLS constraints use, raising ``ValueError`` on a bad value.
+    Shared by :func:`safe_tenant_sql` and :func:`current_tenant_value_sql` so
+    the two helpers never drift in how they resolve and validate config.
+
+    Returns:
+        A ``(guc_current_tenant, tenant_pk_type)`` tuple.
+
+    Raises:
+        ValueError: If the configured GUC name or tenant PK type is invalid.
+    """
+    conf = rls_tenants_config
+    guc_tenant = conf.GUC_CURRENT_TENANT
+    pk_type = conf.TENANT_PK_TYPE
+    _validate_guc_name(guc_tenant)
+    _validate_pk_type(pk_type)
+    return guc_tenant, pk_type
+
+
+def safe_tenant_sql(
+    column: str = "tenant_id",
+    *,
+    table: str | None = None,
+    include_admin: bool = True,
+    extra_bypass_flags: list[str] | None = None,
+) -> str:
+    """Return a ``WHERE``-clause fragment scoping rows to the current tenant.
+
+    The fragment compares ``column`` against the current-tenant GUC, using the
+    exact expression the RLS policies use (via
+    :mod:`~django_rls_tenants.rls.policy_sql`).  When ``include_admin`` is true
+    it also lets rows through while the admin-bypass GUC is set, mirroring
+    ``admin_context()``.  Splice it straight into a raw query::
+
+        sql = f"SELECT * FROM orders WHERE {safe_tenant_sql()} AND amount > %s"
+        cursor.execute(sql, [100])
+
+    There are deliberately no bind parameters: the tenant id is read inside
+    PostgreSQL from the session GUC, so the fragment contains no Python-side
+    user input.
+
+    Args:
+        column: Tenant foreign-key column on the target table. Defaults to
+            ``"tenant_id"`` (Django's column name for a ``tenant`` FK).
+        table: Optional table name/alias to qualify the column with, e.g.
+            ``safe_tenant_sql(table="orders")`` yields ``"orders".tenant_id``.
+            Use it when the query joins several tables and ``column`` would be
+            ambiguous.
+        include_admin: When ``True`` (default), the fragment also matches every
+            row while the admin-bypass GUC is active, so a query run inside
+            ``admin_context()`` sees all tenants -- matching the RLS policy. Set
+            it to ``False`` to scope strictly to the current tenant regardless
+            of admin (or any other bypass) state.
+        extra_bypass_flags: Additional boolean bypass GUCs that should also let
+            rows through, matching the ``extra_bypass_flags`` you passed to the
+            model's :class:`~django_rls_tenants.rls.constraints.RLSConstraint`.
+            Pass the *same* list here so the fragment mirrors the live policy's
+            ``USING`` clause; otherwise a session with one of those flags set
+            passes the policy but is filtered out by this fragment. Only applied
+            when ``include_admin=True`` (these flags extend the bypass set);
+            ignored when ``include_admin=False``.
+
+    Returns:
+        A SQL ``WHERE``-clause fragment. With ``include_admin=True`` it is
+        wrapped in parentheses (``(<match> OR <admin> [OR <flag>...])``) so it
+        composes safely with surrounding ``AND`` clauses. With
+        ``include_admin=False`` it is the bare ``<match>`` predicate.
+
+    Warning:
+        The parentheses only make the fragment safe to combine with ``AND``.
+        Appending ``OR`` defeats tenant isolation -- ``WHERE {safe_tenant_sql()}
+        OR is_public`` returns rows from *every* tenant. Always restrict
+        further with ``AND``, never ``OR``.
+
+    Raises:
+        ValueError: If ``column`` or ``table`` is not a valid SQL identifier, or
+            if the configured GUC names, the tenant PK type, or any
+            ``extra_bypass_flags`` entry is invalid.
+
+    Example:
+        >>> safe_tenant_sql("tenant_id", include_admin=False)
+        "tenant_id = nullif((SELECT current_setting('rls.current_tenant', true)), '')::int"
+
+        The default (``include_admin=True``) wraps that predicate as
+        ``(<predicate> OR (SELECT current_setting('rls.is_admin', true)) = 'true')``.
+    """
+    guc_tenant, pk_type = _validated_tenant_guc_and_pk_type()
+
+    _validate_field_name(column, "column")
+    if table is not None:
+        _validate_field_name(table, "table")
+        col = f'"{table}".{column}'
+    else:
+        col = column
+
+    predicate = tenant_match_sql(col, guc_tenant, pk_type)
+    if not include_admin:
+        return predicate
+
+    # Bypass set mirrors RLSConstraint's USING clause: admin first, then any
+    # extra flags, each read via the same InitPlan-wrapped boolean-flag helper.
+    guc_admin = rls_tenants_config.GUC_IS_ADMIN
+    _validate_guc_name(guc_admin)
+    bypass_conditions = [bool_flag_sql(guc_admin)]
+    for flag in extra_bypass_flags or []:
+        _validate_guc_name(flag)
+        bypass_conditions.append(bool_flag_sql(flag))
+
+    bypass_clause = " OR ".join(bypass_conditions)
+    return f"({predicate} OR {bypass_clause})"
+
+
+def current_tenant_value_sql() -> str:
+    """Return the current-tenant value expression for use in raw SQL.
+
+    Produces the same cast GUC read the RLS policies compare against -- e.g.
+    ``nullif((SELECT current_setting('rls.current_tenant', true)), '')::int`` --
+    suitable for an ``INSERT`` value list or a ``SELECT`` projection::
+
+        cursor.execute(
+            f"INSERT INTO orders (product, tenant_id) VALUES (%s, {current_tenant_value_sql()})",
+            ["Widget"],
+        )
+
+    An unset GUC evaluates to ``NULL`` (via ``nullif(..., '')``), so the cast
+    never fails on an empty string.
+
+    Returns:
+        A SQL value expression yielding the current tenant id (or ``NULL`` when
+        no tenant context is active).
+
+    Raises:
+        ValueError: If the configured GUC name or tenant PK type is invalid.
+
+    Example:
+        >>> current_tenant_value_sql()
+        "nullif((SELECT current_setting('rls.current_tenant', true)), '')::int"
+    """
+    guc_tenant, pk_type = _validated_tenant_guc_and_pk_type()
+    return tenant_value_sql(guc_tenant, pk_type)

--- a/docs/guides/raw-sql.md
+++ b/docs/guides/raw-sql.md
@@ -1,0 +1,173 @@
+# Raw SQL
+
+Sometimes the ORM isn't the right tool: a hand-tuned analytics query, a bulk
+`UPDATE`, a report against a database view. Row-Level Security still protects
+those queries — RLS is enforced by PostgreSQL regardless of how the SQL is
+written — but it's good practice to *also* scope the query explicitly. Adding
+the tenant predicate yourself makes the intent obvious in code review, lets the
+planner use a tenant index, and keeps admin-bypass behaviour identical to the
+live policies.
+
+`django-rls-tenants` gives you two helpers for this, built from the **exact same
+expression** the RLS policies use, so what you write by hand stays **semantically
+consistent** with what the database enforces:
+
+```python
+from django_rls_tenants import safe_tenant_sql, current_tenant_value_sql
+```
+
+## `safe_tenant_sql()`
+
+Returns a `WHERE`-clause fragment that scopes rows to the current tenant. Splice
+it straight into your query:
+
+```python
+from django.db import connection
+from django_rls_tenants import safe_tenant_sql, tenant_context
+
+with tenant_context(tenant.pk), connection.cursor() as cursor:
+    cursor.execute(
+        f"SELECT product, amount FROM orders WHERE {safe_tenant_sql()} AND amount > %s",
+        [100],
+    )
+    rows = cursor.fetchall()
+```
+
+**Parameters:**
+
+| Parameter            | Type                | Default       | Description |
+|----------------------|---------------------|---------------|-------------|
+| `column`             | `str`               | `"tenant_id"` | Tenant FK column on the target table (Django names a `tenant` FK `tenant_id`). Must be a plain identifier — no SQL keywords. |
+| `table`              | `str \| None`       | `None`        | Optional table name/alias to qualify the column with, e.g. `"orders".tenant_id`. Use it when a join makes the bare column ambiguous. |
+| `include_admin`      | `bool`              | `True`        | When `True`, also matches every row while the admin-bypass GUC is set, so a query inside `admin_context()` sees all tenants — matching the RLS policy. Set `False` to scope strictly to the current tenant, ignoring admin (and any other bypass) state. |
+| `extra_bypass_flags` | `list[str] \| None` | `None`        | Extra boolean bypass GUCs to honour, matching the `extra_bypass_flags` on the model's `RLSConstraint`. Pass the **same** list so the fragment mirrors the live policy; otherwise a session with one of those flags set passes the policy but is filtered out here. Only applied when `include_admin=True`. |
+
+With the default `include_admin=True`, the fragment is wrapped in parentheses so
+it composes safely with surrounding `AND` clauses:
+
+```python
+>>> safe_tenant_sql()
+"(tenant_id = nullif((SELECT current_setting('rls.current_tenant', true)), '')::int OR (SELECT current_setting('rls.is_admin', true)) = 'true')"
+
+>>> safe_tenant_sql("tenant_id", include_admin=False)
+"tenant_id = nullif((SELECT current_setting('rls.current_tenant', true)), '')::int"
+```
+
+Passing `table="orders"` qualifies the column for joins — the predicate then
+starts with `"orders".tenant_id = ...` instead of a bare `tenant_id`.
+
+!!! warning "Combine with `AND`, never `OR`"
+    The parentheses only make the fragment safe next to `AND`. Appending `OR`
+    breaks isolation — `WHERE {safe_tenant_sql()} OR is_public` returns rows from
+    **every** tenant, because the trailing `OR` escapes the tenant scope. Always
+    narrow further with `AND`.
+
+The GUC names (`rls.current_tenant`, `rls.is_admin`) and the `::int` cast come
+from your [`RLS_TENANTS` settings](../getting-started/configuration.md) —
+`GUC_PREFIX` and `TENANT_PK_TYPE` — so a custom prefix or a `uuid` PK is honoured
+automatically.
+
+## `current_tenant_value_sql()`
+
+Returns just the current-tenant *value* expression — useful in an `INSERT`
+value list or a `SELECT` projection:
+
+```python
+from django.db import connection
+from django_rls_tenants import current_tenant_value_sql, tenant_context
+
+with tenant_context(tenant.pk), connection.cursor() as cursor:
+    cursor.execute(
+        f"INSERT INTO orders (product, tenant_id) VALUES (%s, {current_tenant_value_sql()})",
+        ["Widget"],
+    )
+```
+
+```python
+>>> current_tenant_value_sql()
+"nullif((SELECT current_setting('rls.current_tenant', true)), '')::int"
+```
+
+When no context is active the expression evaluates to `NULL` (via
+`nullif(..., '')`), so the cast never fails on an empty string.
+
+## How it works
+
+### No bind parameters
+
+Neither helper takes or emits a bind parameter. The tenant id is read **inside
+PostgreSQL** from the session GUC — the one `tenant_context()`, `admin_context()`,
+or [`RLSTenantMiddleware`](middleware.md) set — so the fragment contains zero
+Python-side user input. You splice the fragment in with an f-string and pass
+*your* parameters separately:
+
+```python
+cursor.execute(
+    f"SELECT * FROM orders WHERE {safe_tenant_sql()} AND status = %s",
+    ["shipped"],   # <- your params still go through the driver
+)
+```
+
+This is safe precisely because the fragment is built only from your own
+configuration and validated identifiers, never from request data.
+
+### Requires an active context
+
+Both helpers read the session GUC, so they only scope correctly when a context
+is active. Wrap the query in `tenant_context()` / `admin_context()`, or run it
+inside a request handled by `RLSTenantMiddleware`. With **no** context set,
+`safe_tenant_sql(include_admin=False)` evaluates to `tenant_id = NULL` and
+matches nothing — fail-closed, the same as RLS itself.
+
+### Injection safety
+
+Every identifier interpolated into the fragment is validated against the same
+allowlists the RLS constraints use:
+
+- `column` and `table` must be plain SQL identifiers (`[a-zA-Z_][a-zA-Z0-9_]*`).
+- The GUC names derived from `GUC_PREFIX` are checked against the GUC-name
+  pattern.
+- `TENANT_PK_TYPE` must be one of `int`, `bigint`, `uuid`.
+
+An invalid value raises `ValueError` rather than producing injectable SQL:
+
+```python
+>>> safe_tenant_sql("tenant_id; DROP TABLE orders")
+Traceback (most recent call last):
+    ...
+ValueError: Invalid field name for column: 'tenant_id; DROP TABLE orders'. ...
+```
+
+### Equivalent to the policy predicate
+
+The fragment is produced by the same internal helpers as `RLSConstraint`, so it
+applies the **same row-visibility rule** as the policy's `USING` clause —
+including the v1.3.0 [InitPlan-wrapped GUC reads](../advanced/migration-guide.md)
+that evaluate each GUC once per statement.
+
+The bare tenant match (`include_admin=False`) is byte-for-byte the policy
+predicate. The admin-inclusive form is spelled `(<match> OR <admin>)` rather than
+the policy's `CASE WHEN <admin> THEN true ELSE <match> END` — the same truth
+table, not the same string, so don't expect it to match `pg_policies.qual`
+character-for-character. If your model's `RLSConstraint` sets `extra_bypass_flags`,
+pass the same list to `safe_tenant_sql()` so those flags are honoured here too:
+
+```python
+# Model: RLSConstraint(field="tenant", extra_bypass_flags=["rls.is_login_request"])
+safe_tenant_sql(extra_bypass_flags=["rls.is_login_request"])
+```
+
+## Why no full-query wrapper?
+
+A natural request is "just give me a function that takes my whole SQL string and
+adds the tenant filter." We deliberately **don't** ship that. Reliably injecting
+a `WHERE` clause into an arbitrary SQL statement means parsing SQL — handling
+existing `WHERE`/`GROUP BY`/`HAVING`/`UNION`/subqueries/CTEs — which is fragile
+and a security footgun the moment it gets it wrong. The fragment pattern shown
+above is explicit, predictable, and puts you in control of exactly where the
+predicate lands.
+
+!!! note "Sync only"
+    Like the rest of v1.3.0, these helpers are synchronous. They build a SQL
+    string and read the GUC your synchronous context set; there is no async/ASGI
+    variant yet.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -17,6 +17,8 @@ from django_rls_tenants import (
     TenantQuerySet,
     TenantUser,
     admin_context,
+    current_tenant_value_sql,
+    safe_tenant_sql,
     tenant_context,
     with_rls_context,
 )
@@ -105,6 +107,15 @@ Django multitenancy built on top of the `rls/` primitives.
 ::: django_rls_tenants.tenants.context.admin_context
 
 ::: django_rls_tenants.tenants.context.with_rls_context
+
+### Raw SQL
+
+Helpers for scoping hand-written SQL to the current tenant. See the
+[Raw SQL guide](../guides/raw-sql.md) for usage and safety notes.
+
+::: django_rls_tenants.tenants.sql.safe_tenant_sql
+
+::: django_rls_tenants.tenants.sql.current_tenant_value_sql
 
 ### State
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,7 @@ nav:
       - User Integration: guides/user-integration.md
       - Middleware: guides/middleware.md
       - Context Managers: guides/context-managers.md
+      - Raw SQL: guides/raw-sql.md
       - Celery Tasks: guides/celery-tasks.md
       - Bypass Mode: guides/bypass-mode.md
       - Testing: guides/testing.md

--- a/tests/test_integration/test_sql_helpers.py
+++ b/tests/test_integration/test_sql_helpers.py
@@ -1,0 +1,160 @@
+"""Integration tests for the raw-SQL helpers (issue #33).
+
+These require a live PostgreSQL database with RLS policies applied and run under
+the non-superuser ``rls_test_role`` (RLS enforced), via the ``enforce_rls``
+fixture auto-applied in this package's conftest.
+
+They prove the ``safe_tenant_sql`` fragment actually scopes a raw query to the
+current tenant -- including independently of RLS, by running under
+``admin_context()`` (which bypasses RLS) and showing the fragment alone still
+filters -- and that ``current_tenant_value_sql`` yields the active tenant id.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from django.db import connection
+
+from django_rls_tenants.rls.guc import set_guc
+from django_rls_tenants.tenants.context import admin_context, tenant_context
+from django_rls_tenants.tenants.sql import current_tenant_value_sql, safe_tenant_sql
+
+pytestmark = pytest.mark.django_db
+
+
+class TestSafeTenantSqlFragment:
+    """safe_tenant_sql() scopes raw queries to the current tenant."""
+
+    def test_fragment_scopes_to_current_tenant(self, sample_orders, tenant_a):
+        """Under tenant_context, the fragment returns only that tenant's rows."""
+        with tenant_context(tenant_a.pk), connection.cursor() as cursor:
+            cursor.execute(f"SELECT product FROM test_order WHERE {safe_tenant_sql()}")
+            products = sorted(row[0] for row in cursor.fetchall())
+        assert products == ["Widget A1", "Widget A2"]
+
+    def test_admin_sees_all_via_admin_branch(self, sample_orders):
+        """include_admin=True lets an admin_context query see every tenant's rows."""
+        with admin_context(), connection.cursor() as cursor:
+            cursor.execute(f"SELECT count(*) FROM test_order WHERE {safe_tenant_sql()}")
+            count = cursor.fetchone()[0]
+        assert count == 3
+
+    def test_include_admin_false_scopes_even_under_admin(self, sample_orders, tenant_a):
+        """The fragment itself filters, independently of RLS.
+
+        admin_context() bypasses RLS (all rows are visible at the policy level),
+        yet ``safe_tenant_sql(include_admin=False)`` with the tenant GUC set to A
+        still returns only A's rows -- proving the WHERE fragment does the
+        scoping, not the policy.
+        """
+        with admin_context(), connection.cursor() as cursor:
+            set_guc("rls.current_tenant", str(tenant_a.pk))
+            cursor.execute(
+                f"SELECT product FROM test_order WHERE {safe_tenant_sql(include_admin=False)}"
+            )
+            products = sorted(row[0] for row in cursor.fetchall())
+        assert products == ["Widget A1", "Widget A2"]
+
+    def test_include_admin_false_fail_closed_without_tenant(self, sample_orders):
+        """With no tenant set, the bare fragment matches nothing (fail-closed).
+
+        Even under admin_context() (RLS bypassed), an empty current_tenant GUC
+        makes the predicate ``tenant_id = NULL`` -- so zero rows match.
+        """
+        with admin_context(), connection.cursor() as cursor:
+            cursor.execute(
+                f"SELECT count(*) FROM test_order WHERE {safe_tenant_sql(include_admin=False)}"
+            )
+            count = cursor.fetchone()[0]
+        assert count == 0
+
+    def test_table_qualified_fragment(self, sample_orders, tenant_a):
+        """A table-qualified fragment works in a real query."""
+        with tenant_context(tenant_a.pk), connection.cursor() as cursor:
+            cursor.execute(
+                f"SELECT product FROM test_order WHERE {safe_tenant_sql(table='test_order')}"
+            )
+            products = sorted(row[0] for row in cursor.fetchall())
+        assert products == ["Widget A1", "Widget A2"]
+
+    def test_table_qualified_fragment_with_admin_context(self, sample_orders):
+        """A table-qualified fragment composes with the admin branch in a live query."""
+        with admin_context(), connection.cursor() as cursor:
+            cursor.execute(
+                f"SELECT count(*) FROM test_order WHERE {safe_tenant_sql(table='test_order')}"
+            )
+            count = cursor.fetchone()[0]
+        assert count == 3
+
+    def test_fragment_composes_safely_with_trailing_and(self, sample_orders, tenant_a):
+        """The parenthesized fragment composes correctly with a trailing AND filter.
+
+        Tenant A owns Widget A1 (10.00) and Widget A2 (20.00); ``AND amount < 15``
+        must exclude A2. Were the fragment's outer parens dropped, OR/AND
+        precedence would turn ``... OR is_admin AND amount < 15`` into
+        ``tenant_match OR (is_admin AND amount < 15)`` and let A2 slip through.
+        """
+        with tenant_context(tenant_a.pk), connection.cursor() as cursor:
+            cursor.execute(
+                f"SELECT product FROM test_order WHERE {safe_tenant_sql()} AND amount < %s",
+                [15],
+            )
+            products = sorted(row[0] for row in cursor.fetchall())
+        assert products == ["Widget A1"]
+
+    def test_extra_bypass_flag_matches_policy_bypass(self, sample_protected_users):
+        """extra_bypass_flags mirrors the live policy; omitting it diverges.
+
+        ``ProtectedUser`` carries ``extra_bypass_flags=["rls.is_login_request",
+        ...]``. With that GUC set (and no tenant/admin context), the RLS policy
+        makes every row visible. The flag-aware fragment matches them all; the
+        flag-unaware fragment -- now out of step with the policy -- matches none.
+        """
+        flag_aware = safe_tenant_sql(extra_bypass_flags=["rls.is_login_request"])
+        flag_unaware = safe_tenant_sql()
+        with connection.cursor() as cursor:
+            set_guc("rls.is_login_request", "true")
+            cursor.execute(f"SELECT count(*) FROM test_protected_user WHERE {flag_aware}")
+            with_flag = cursor.fetchone()[0]
+            cursor.execute(f"SELECT count(*) FROM test_protected_user WHERE {flag_unaware}")
+            without_flag = cursor.fetchone()[0]
+        assert with_flag == 2
+        assert without_flag == 0
+
+
+class TestCurrentTenantValueSqlFragment:
+    """current_tenant_value_sql() yields the active tenant id in raw SQL."""
+
+    def test_returns_active_tenant_id(self, tenant_a):
+        """SELECTing the value expression returns the current tenant's id."""
+        with tenant_context(tenant_a.pk), connection.cursor() as cursor:
+            cursor.execute(f"SELECT {current_tenant_value_sql()}")
+            value = cursor.fetchone()[0]
+        assert value == tenant_a.pk
+
+    def test_null_without_context(self):
+        """With no tenant context the value expression is NULL."""
+        with admin_context(), connection.cursor() as cursor:
+            cursor.execute(f"SELECT {current_tenant_value_sql()}")
+            value = cursor.fetchone()[0]
+        assert value is None
+
+    def test_usable_as_insert_value(self, tenant_a):
+        """The value expression supplies tenant_id on a raw INSERT.
+
+        Under tenant_context the inserted row's tenant_id matches the GUC, so it
+        also satisfies the RLS WITH CHECK clause.
+        """
+        with tenant_context(tenant_a.pk), connection.cursor() as cursor:
+            cursor.execute(
+                f"INSERT INTO test_order (product, amount, tenant_id) "
+                f"VALUES (%s, %s, {current_tenant_value_sql()})",
+                ["Raw Widget", Decimal("9.99")],
+            )
+        with admin_context():
+            from tests.test_app.models import Order  # noqa: PLC0415
+
+            inserted = Order.objects.get(product="Raw Widget")
+        assert inserted.tenant_id == tenant_a.pk

--- a/tests/test_layering.py
+++ b/tests/test_layering.py
@@ -62,6 +62,17 @@ class TestLazyImports:
         assert admin_context is ctx_mod.admin_context
         assert tenant_context is ctx_mod.tenant_context
 
+    def test_raw_sql_helpers(self):
+        """The raw-SQL helpers are importable from the top-level package."""
+        from django_rls_tenants import (  # noqa: PLC0415
+            current_tenant_value_sql,
+            safe_tenant_sql,
+        )
+        from django_rls_tenants.tenants import sql as sql_mod  # noqa: PLC0415
+
+        assert safe_tenant_sql is sql_mod.safe_tenant_sql
+        assert current_tenant_value_sql is sql_mod.current_tenant_value_sql
+
     def test_invalid_attribute_raises(self):
         """Accessing an undefined attribute raises AttributeError."""
         import django_rls_tenants  # noqa: PLC0415

--- a/tests/test_rls/test_guc.py
+++ b/tests/test_rls/test_guc.py
@@ -91,6 +91,11 @@ class TestGucNameValidation:
         with pytest.raises(ValueError, match="Invalid GUC variable name"):
             set_guc("rls()", "val")
 
+    def test_trailing_newline(self):
+        """A trailing newline is rejected (\\Z anchor, not $, which allows it)."""
+        with pytest.raises(ValueError, match="Invalid GUC variable name"):
+            set_guc("rls.current_tenant\n", "val")
+
     def test_get_guc_also_validates(self):
         """get_guc rejects invalid names too."""
         with pytest.raises(ValueError, match="Invalid GUC variable name"):

--- a/tests/test_tenants/test_sql.py
+++ b/tests/test_tenants/test_sql.py
@@ -1,0 +1,275 @@
+"""Tests for django_rls_tenants.tenants.sql (issue #33).
+
+These cover the raw-SQL helpers ``safe_tenant_sql`` and
+``current_tenant_value_sql``: the exact fragments they emit, that they reuse the
+InitPlan-wrapped policy SQL (#57), how they honour ``RLS_TENANTS`` config, and
+that every interpolated identifier is validated.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from typing import TYPE_CHECKING
+
+import pytest
+from django.test import override_settings
+
+from django_rls_tenants.rls.policy_sql import bool_flag_sql, tenant_match_sql, tenant_value_sql
+from django_rls_tenants.tenants.conf import rls_tenants_config
+from django_rls_tenants.tenants.sql import current_tenant_value_sql, safe_tenant_sql
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+@contextlib.contextmanager
+def _override_rls_tenants(**rls_tenants: object) -> Iterator[None]:
+    """``override_settings(RLS_TENANTS=...)`` that also resets the cached config.
+
+    ``rls_tenants_config`` caches the settings dict on first read and has no
+    settings-changed hook, so the cache must be cleared before and after the
+    override for the new values to take effect (same pattern as test_context.py).
+    """
+    rls_tenants.setdefault("TENANT_MODEL", "test_app.Tenant")
+    with override_settings(RLS_TENANTS=rls_tenants):
+        rls_tenants_config._config_cache = None
+        rls_tenants_config._unknown_keys_checked = False
+        try:
+            yield
+        finally:
+            rls_tenants_config._config_cache = None
+            rls_tenants_config._unknown_keys_checked = False
+
+
+# Default test settings: GUC_PREFIX="rls", TENANT_PK_TYPE="int".
+_DEFAULT_PREDICATE = (
+    "tenant_id = nullif((SELECT current_setting('rls.current_tenant', true)), '')::int"
+)
+_DEFAULT_ADMIN = "(SELECT current_setting('rls.is_admin', true)) = 'true'"
+
+
+class TestSafeTenantSql:
+    """Tests for safe_tenant_sql()."""
+
+    def test_default(self):
+        """Default column + include_admin wraps the match OR the admin flag."""
+        assert safe_tenant_sql() == f"({_DEFAULT_PREDICATE} OR {_DEFAULT_ADMIN})"
+
+    def test_include_admin_false_is_bare_predicate(self):
+        """include_admin=False drops the admin branch and the wrapping parens."""
+        assert safe_tenant_sql(include_admin=False) == _DEFAULT_PREDICATE
+
+    def test_custom_column(self):
+        """A custom column name is interpolated verbatim."""
+        assert safe_tenant_sql("org_id", include_admin=False) == (
+            "org_id = nullif((SELECT current_setting('rls.current_tenant', true)), '')::int"
+        )
+
+    def test_table_qualified_column(self):
+        """table= double-quotes the table and qualifies the (unquoted) column."""
+        assert safe_tenant_sql(table="orders", include_admin=False) == (
+            '"orders".tenant_id = '
+            "nullif((SELECT current_setting('rls.current_tenant', true)), '')::int"
+        )
+
+    def test_table_qualified_with_admin(self):
+        """table= composes with the admin branch."""
+        assert safe_tenant_sql("tenant_id", table="orders") == (
+            '("orders".tenant_id = '
+            "nullif((SELECT current_setting('rls.current_tenant', true)), '')::int "
+            "OR (SELECT current_setting('rls.is_admin', true)) = 'true')"
+        )
+
+    def test_custom_column_and_table_combined(self):
+        """A custom column and a table qualifier compose: ``"orders".org_id``."""
+        assert safe_tenant_sql("org_id", table="orders", include_admin=False) == (
+            '"orders".org_id = '
+            "nullif((SELECT current_setting('rls.current_tenant', true)), '')::int"
+        )
+
+    def test_include_admin_defaults_true(self):
+        """The admin branch is present unless explicitly disabled."""
+        assert " OR " in safe_tenant_sql()
+        assert " OR " not in safe_tenant_sql(include_admin=False)
+
+    def test_matches_policy_predicate_exactly(self):
+        """The bare fragment is byte-for-byte the policy's tenant-match expression (#57).
+
+        This is the policy's ``ELSE`` branch; the admin-inclusive form spells the
+        bypass as ``OR`` rather than the policy's ``CASE WHEN`` (same truth table,
+        different string), so only the bare predicate is compared here.
+        """
+        conf = rls_tenants_config
+        expected = tenant_match_sql("tenant_id", conf.GUC_CURRENT_TENANT, conf.TENANT_PK_TYPE)
+        assert safe_tenant_sql(include_admin=False) == expected
+
+    def test_reads_are_initplan_wrapped(self):
+        """GUC reads use the (SELECT current_setting(...)) InitPlan form, not inline."""
+        sql = safe_tenant_sql()
+        assert "(SELECT current_setting(" in sql
+        # The pre-#57 inline read must not appear.
+        assert "nullif(current_setting(" not in sql
+
+    def test_no_bind_params(self):
+        """The fragment carries no %s placeholders -- the tenant id is read in-DB."""
+        assert "%s" not in safe_tenant_sql()
+        assert "%s" not in safe_tenant_sql(include_admin=False)
+
+
+class TestExtraBypassFlags:
+    """safe_tenant_sql() mirrors RLSConstraint's extra_bypass_flags bypass set."""
+
+    _LOGIN_FLAG = "(SELECT current_setting('rls.is_login_request', true)) = 'true'"
+    _PREAUTH_FLAG = "(SELECT current_setting('rls.is_preauth_request', true)) = 'true'"
+
+    def test_single_extra_flag_appended_after_admin(self):
+        """An extra flag is OR-ed in after the admin flag (policy ordering)."""
+        assert safe_tenant_sql(extra_bypass_flags=["rls.is_login_request"]) == (
+            f"({_DEFAULT_PREDICATE} OR {_DEFAULT_ADMIN} OR {self._LOGIN_FLAG})"
+        )
+
+    def test_multiple_extra_flags_keep_order(self):
+        """Multiple flags are appended in the given order, after admin."""
+        assert safe_tenant_sql(
+            extra_bypass_flags=["rls.is_login_request", "rls.is_preauth_request"]
+        ) == (
+            f"({_DEFAULT_PREDICATE} OR {_DEFAULT_ADMIN} "
+            f"OR {self._LOGIN_FLAG} OR {self._PREAUTH_FLAG})"
+        )
+
+    def test_empty_list_matches_no_flags(self):
+        """An empty list is equivalent to omitting the argument."""
+        assert safe_tenant_sql(extra_bypass_flags=[]) == safe_tenant_sql()
+
+    def test_flags_ignored_when_include_admin_false(self):
+        """include_admin=False scopes strictly, ignoring extra bypass flags."""
+        assert safe_tenant_sql(
+            extra_bypass_flags=["rls.is_login_request"], include_admin=False
+        ) == safe_tenant_sql(include_admin=False)
+
+    def test_flags_use_initplan_bool_flag_helper(self):
+        """Each flag is emitted via the same InitPlan-wrapped helper as the policy."""
+        sql = safe_tenant_sql(extra_bypass_flags=["rls.is_login_request"])
+        assert bool_flag_sql("rls.is_login_request") in sql
+
+    def test_invalid_extra_flag_raises(self):
+        """A malformed flag GUC name is rejected before producing SQL."""
+        with pytest.raises(ValueError, match="Invalid GUC variable name"):
+            safe_tenant_sql(extra_bypass_flags=["bad flag"])
+
+
+class TestCurrentTenantValueSql:
+    """Tests for current_tenant_value_sql()."""
+
+    def test_default(self):
+        """Emits the cast GUC read used on the right-hand side of the policy."""
+        assert current_tenant_value_sql() == (
+            "nullif((SELECT current_setting('rls.current_tenant', true)), '')::int"
+        )
+
+    def test_matches_policy_value_exactly(self):
+        """Byte-for-byte the policy's tenant-value expression (#57)."""
+        conf = rls_tenants_config
+        expected = tenant_value_sql(conf.GUC_CURRENT_TENANT, conf.TENANT_PK_TYPE)
+        assert current_tenant_value_sql() == expected
+
+    def test_reads_are_initplan_wrapped(self):
+        """The GUC read is wrapped in a scalar sub-SELECT, not inline."""
+        sql = current_tenant_value_sql()
+        assert "(SELECT current_setting(" in sql
+        assert "nullif(current_setting(" not in sql
+
+
+class TestConfigDerived:
+    """safe_tenant_sql() / current_tenant_value_sql() honour RLS_TENANTS."""
+
+    def test_custom_guc_prefix(self):
+        """A custom GUC_PREFIX flows into the tenant, admin, and value reads."""
+        with _override_rls_tenants(GUC_PREFIX="myco"):
+            assert safe_tenant_sql() == (
+                "(tenant_id = "
+                "nullif((SELECT current_setting('myco.current_tenant', true)), '')::int "
+                "OR (SELECT current_setting('myco.is_admin', true)) = 'true')"
+            )
+            assert current_tenant_value_sql() == (
+                "nullif((SELECT current_setting('myco.current_tenant', true)), '')::int"
+            )
+
+    def test_uuid_pk_type(self):
+        """TENANT_PK_TYPE drives the ::cast on both helpers."""
+        with _override_rls_tenants(TENANT_PK_TYPE="uuid"):
+            value = "nullif((SELECT current_setting('rls.current_tenant', true)), '')::uuid"
+            assert safe_tenant_sql(include_admin=False) == f"tenant_id = {value}"
+            assert current_tenant_value_sql() == value
+
+    def test_bigint_pk_type(self):
+        """bigint is in the PK-type allowlist and drives the ::cast on both helpers."""
+        with _override_rls_tenants(TENANT_PK_TYPE="bigint"):
+            value = "nullif((SELECT current_setting('rls.current_tenant', true)), '')::bigint"
+            assert safe_tenant_sql(include_admin=False) == f"tenant_id = {value}"
+            assert current_tenant_value_sql() == value
+
+
+class TestValidation:
+    """Every interpolated identifier is validated against the RLS allowlists."""
+
+    def test_invalid_column_raises(self):
+        """A non-identifier column is rejected, not interpolated."""
+        with pytest.raises(ValueError, match="Invalid field name for column"):
+            safe_tenant_sql("tenant_id; DROP TABLE orders")
+
+    def test_invalid_column_with_dash_raises(self):
+        with pytest.raises(ValueError, match="Invalid field name for column"):
+            safe_tenant_sql("bad-column")
+
+    def test_invalid_table_raises(self):
+        """A non-identifier table is rejected even though it is double-quoted."""
+        with pytest.raises(ValueError, match="Invalid field name for table"):
+            safe_tenant_sql("tenant_id", table='orders" OR "1"="1')
+
+    def test_empty_column_raises(self):
+        """An empty column name is rejected (regex requires >= 1 char)."""
+        with pytest.raises(ValueError, match="Invalid field name for column"):
+            safe_tenant_sql("")
+
+    def test_empty_table_raises(self):
+        """An empty table name is rejected."""
+        with pytest.raises(ValueError, match="Invalid field name for table"):
+            safe_tenant_sql("tenant_id", table="")
+
+    def test_column_with_trailing_newline_raises(self):
+        """A trailing newline is rejected (\\Z anchor, not $)."""
+        with pytest.raises(ValueError, match="Invalid field name for column"):
+            safe_tenant_sql("tenant_id\n")
+
+    def test_invalid_guc_prefix_raises(self):
+        """A malformed GUC_PREFIX is rejected before producing SQL."""
+        with (
+            _override_rls_tenants(GUC_PREFIX="bad prefix"),
+            pytest.raises(ValueError, match="Invalid GUC variable name"),
+        ):
+            safe_tenant_sql()
+
+    def test_invalid_pk_type_raises(self):
+        """A TENANT_PK_TYPE outside the allowlist is rejected."""
+        with (
+            _override_rls_tenants(TENANT_PK_TYPE="text"),
+            pytest.raises(ValueError, match="Invalid tenant_pk_type"),
+        ):
+            safe_tenant_sql()
+
+    def test_current_tenant_value_sql_invalid_guc_prefix_raises(self):
+        """current_tenant_value_sql() also rejects a malformed GUC_PREFIX."""
+        with (
+            _override_rls_tenants(GUC_PREFIX="bad prefix"),
+            pytest.raises(ValueError, match="Invalid GUC variable name"),
+        ):
+            current_tenant_value_sql()
+
+    def test_current_tenant_value_sql_invalid_pk_type_raises(self):
+        """current_tenant_value_sql() also rejects a bad TENANT_PK_TYPE."""
+        with (
+            _override_rls_tenants(TENANT_PK_TYPE="text"),
+            pytest.raises(ValueError, match="Invalid tenant_pk_type"),
+        ):
+            current_tenant_value_sql()


### PR DESCRIPTION
Closes #33

## Summary

Adds two raw-SQL helpers in `django_rls_tenants/tenants/sql.py` for scoping
hand-written SQL to the current tenant, built from the same
InitPlan-wrapped (`#57`) `current_setting()` fragments the RLS policies use:

- **`safe_tenant_sql(column="tenant_id", *, table=None, include_admin=True, extra_bypass_flags=None)`**
  — returns a `WHERE`-clause fragment.
- **`current_tenant_value_sql()`** — returns the current-tenant value
  expression for `INSERT` / `SELECT` value lists.

The tenant id is read in-database from the session GUC, so the fragments
carry **no bind parameters**; every interpolated identifier (column, table,
GUC names, PK cast, bypass flags) is validated against the existing RLS
allowlists. Both are re-exported lazily from the top-level package.

## Deep review + fixes applied on top of the initial implementation

This branch went through a multi-lens review (security, Python quality,
test quality, correctness/perf). The headline claims were verified against
a live PostgreSQL: the admin-inclusive `(match OR admin)` form is
`IS NOT DISTINCT FROM` the policy's `CASE WHEN admin THEN true ELSE match END`
across the full NULL-aware truth table, and `EXPLAIN` confirms the GUC reads
are hoisted into a once-per-statement `InitPlan`. Fixes made:

- **`extra_bypass_flags` support (correctness):** `RLSConstraint` supports
  `extra_bypass_flags` (the bundled `ProtectedUser` model uses them), but the
  helper previously ignored them — so a session with such a flag set passed
  the live policy yet was filtered out by the manual `WHERE`. The helper now
  accepts and mirrors them. Covered by a new end-to-end test proving the
  flag-aware fragment matches the policy while the flag-unaware one diverges.
- **Doc accuracy:** replaced the inaccurate "byte-for-byte identical to the
  policy predicate" claim with "semantically equivalent" (the admin form is
  `OR`, the policy is `CASE WHEN` — same truth table, different string).
- **OR-composition caveat:** documented that the fragment composes only with
  `AND`; a trailing `OR` defeats isolation.
- **Validation hardening:** anchored `_FIELD_NAME_RE` / `_GUC_NAME_RE` with
  `\Z` instead of `$` (which admits a trailing newline). Now relevant because
  `extra_bypass_flags` passes user-supplied GUC names through validation.
- **Misc:** fixed a missing `tenant_context` import in the module docstring
  example; extracted a shared conf-read/validate helper (DRY).

### Considered but intentionally not changed
- **Column double-quoting** (`"orders".tenant_id` quotes the table, not the
  column): quoting the column would break the genuine byte-for-byte match with
  the live policy (`constraints.py` uses a bare `{field}_id`). Kept consistent
  with the policy and documented that columns must be plain identifiers.
- **GUC-validator duplication** (`_validate_guc_name` vs
  `_validate_guc_name_for_ddl`): pre-existing; unifying would change error
  messages asserted by existing tests. Out of scope for this PR.

## Tests
- Full suite: **569 passed** (added 16 tests), `sql.py` at **100%** coverage,
  total **92.48%**.
- `ruff check`, `ruff format --check`, `mypy --strict`, and
  `mkdocs build --strict` all pass.
- New tests cover `extra_bypass_flags` (unit + integration), AND-composition
  in a live query, `table=` × `admin_context`, `bigint` PK, empty-string and
  trailing-newline rejection, the custom-prefix `current_tenant_value_sql`
  path, and the top-level lazy-export wiring.

## Docs
- New **Raw SQL** guide (`docs/guides/raw-sql.md`) and API reference entries.
