### PR TITLE
feat: native Celery integration (#32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   re-exported from the top-level package, and are documented in the new Raw SQL
   guide.
 
+- **Native Celery integration** (#32): a new optional `celery` extra
+  (`pip install django-rls-tenants[celery]`) adds `django_rls_tenants.contrib.celery`.
+  `@rls_task` (a `shared_task` drop-in) and the `RLSTask` base class capture the
+  active tenant/admin context into the task's message headers on enqueue and
+  restore it on the worker — around the whole body, so it unwinds on both success
+  and exception — without passing `tenant_id` by hand. Context propagates across
+  chains, groups, and chords (every step must use the integration). Set
+  `rls_require_context = True` on an `RLSTask` subclass to fail fast (with the #34
+  hint) instead of running unscoped. `install()` / `uninstall()` wire the same
+  behaviour globally via Celery signals as an escape hatch for tasks that cannot
+  be re-based. Celery stays optional and is **not** re-exported from the
+  top-level package; importing the module without Celery raises a clear
+  `ImportError`. Synchronous task bodies only (`async def` is out of scope for
+  v1.3.0).
+
 ### Changed
 
 - **Performance: InitPlan-wrapped GUC reads** (#57): RLS policy predicates now

--- a/django_rls_tenants/contrib/__init__.py
+++ b/django_rls_tenants/contrib/__init__.py
@@ -1,0 +1,13 @@
+"""Optional integrations with third-party libraries.
+
+Each module in this subpackage glues django-rls-tenants to a framework that the
+core library deliberately does **not** depend on. Importing this package is
+always safe; importing a specific integration module (for example
+:mod:`django_rls_tenants.contrib.celery`) requires the corresponding extra to be
+installed and raises a helpful :class:`ImportError` otherwise.
+
+The core ``tenants/`` and ``rls/`` layers never import anything from here, so a
+project that does not use Celery never pays for it.
+"""
+
+from __future__ import annotations

--- a/django_rls_tenants/contrib/celery.py
+++ b/django_rls_tenants/contrib/celery.py
@@ -1,0 +1,365 @@
+"""Native Celery integration: propagate the RLS context into background tasks.
+
+A Celery task runs outside the request/response cycle, so
+:class:`~django_rls_tenants.tenants.middleware.RLSTenantMiddleware` never sets a
+context for it. Without help, every task body has to remember to wrap itself in
+``tenant_context()`` -- and a task that forgets silently reads zero rows
+(fail-closed) or, with ``STRICT_MODE``, raises. That is a data-leak risk waiting
+to happen.
+
+This module closes the gap. The active tenant (or admin) context is captured
+into the task's message **headers** when it is enqueued and restored on the
+worker before the task body runs:
+
+- :func:`rls_task` -- a drop-in replacement for ``shared_task`` that wires the
+  capture/restore in for you (the recommended API).
+- :class:`RLSTask` -- the Celery ``Task`` base class doing the work; use it
+  directly via ``shared_task(base=RLSTask)`` when you need a custom base.
+- :func:`install` / :func:`uninstall` -- an opt-in, signal-based escape hatch
+  that propagates context for tasks you cannot re-base onto :class:`RLSTask`
+  (for example third-party tasks).
+
+Capture covers chains, groups, and chords: when the worker enqueues the next
+step of a canvas, the upstream task is still the *current* task, so its headers
+are inherited even though its ``tenant_context`` has already closed. Every task
+participating in a canvas must use :class:`RLSTask` (or :func:`install`) for the
+context to flow all the way through.
+
+Scope:
+    Synchronous task bodies only. ``async def`` task bodies are not supported in
+    v1.3.0 -- the context is set on the calling thread, which an event loop does
+    not propagate to coroutines. Keep RLS-touching task bodies synchronous.
+
+This is an **optional** integration. It imports :mod:`celery`, which is not a
+dependency of the core library; install it with ``pip install
+django-rls-tenants[celery]``. Nothing in ``tenants/`` or ``rls/`` imports this
+module, and it is intentionally **not** re-exported from the top-level package.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+try:
+    from celery import Task, current_task, shared_task
+    from celery.signals import before_task_publish, task_postrun, task_prerun
+except ImportError as exc:  # pragma: no cover - exercised only without the extra
+    msg = (
+        "django_rls_tenants.contrib.celery requires Celery. "
+        "Install it with: pip install django-rls-tenants[celery]"
+    )
+    raise ImportError(msg) from exc
+
+from django_rls_tenants.exceptions import NoTenantContextError
+from django_rls_tenants.tenants.context import admin_context, tenant_context
+from django_rls_tenants.tenants.errors import HINT_NO_CONTEXT
+from django_rls_tenants.tenants.state import get_current_tenant_id, get_rls_context_active
+
+if TYPE_CHECKING:
+    from contextlib import AbstractContextManager
+
+logger = logging.getLogger("django_rls_tenants")
+
+# Message-header keys carrying the captured context. They travel in the task's
+# protocol-v2 headers and surface on the worker as ``self.request.headers``.
+_TENANT_HEADER = "rls_tenant_id"
+_ADMIN_HEADER = "rls_admin"
+
+
+def _capture() -> dict[str, Any]:
+    """Capture the active RLS context as task-header values.
+
+    Resolution order:
+
+    1. A live ``tenant_context()`` -- the common case, enqueuing from a view,
+       the middleware's request context, or an explicit ``tenant_context()``.
+    2. A live ``admin_context()`` (active flag set but no tenant id).
+    3. The currently-executing task's headers. On a worker, the next step of a
+       canvas is enqueued *after* the upstream task's ``tenant_context`` has
+       closed, but while that task is still :data:`celery.current_task`, so its
+       headers are inherited and the context flows through the chain.
+
+    Returns:
+        A header dict to merge into the outgoing task, or an empty dict when no
+        context is active (the task is enqueued unscoped -- fail-closed).
+    """
+    tenant_id = get_current_tenant_id()
+    if tenant_id is not None:
+        return {_TENANT_HEADER: tenant_id, _ADMIN_HEADER: False}
+    if get_rls_context_active():
+        return {_TENANT_HEADER: None, _ADMIN_HEADER: True}
+
+    # Canvas propagation. ``current_task`` outside a task is a proxy wrapping
+    # ``None`` whose attribute access raises -- ``getattr(..., None)`` turns that
+    # into a safe ``None`` rather than an exception.
+    request = getattr(current_task, "request", None)
+    headers = getattr(request, "headers", None)
+    if isinstance(headers, dict) and _TENANT_HEADER in headers:
+        return {
+            _TENANT_HEADER: headers[_TENANT_HEADER],
+            _ADMIN_HEADER: bool(headers.get(_ADMIN_HEADER, False)),
+        }
+    return {}
+
+
+def _request_context(request: Any) -> tuple[Any, bool]:
+    """Extract ``(tenant_id, is_admin)`` from a task request's headers.
+
+    Reads the protocol-v2 ``request.headers`` dict first (where custom headers
+    land in Celery 5), then falls back to top-level request attributes for
+    transports/configurations that surface headers that way instead.
+
+    Args:
+        request: The task's ``self.request`` (a Celery ``Context``), or ``None``.
+
+    Returns:
+        ``(tenant_id, is_admin)``. ``tenant_id`` is ``None`` for admin context or
+        when no context was propagated; ``is_admin`` is then the discriminator.
+    """
+    headers = getattr(request, "headers", None)
+    if isinstance(headers, dict) and _TENANT_HEADER in headers:
+        return headers[_TENANT_HEADER], bool(headers.get(_ADMIN_HEADER, False))
+    return getattr(request, _TENANT_HEADER, None), bool(getattr(request, _ADMIN_HEADER, False))
+
+
+def _merge_headers(options: dict[str, Any]) -> dict[str, Any]:
+    """Pop ``headers`` from ``options`` and merge the captured context into it.
+
+    ``setdefault`` keeps the call idempotent and never clobbers headers a caller
+    set explicitly -- an explicit ``rls_tenant_id`` header always wins.
+
+    Args:
+        options: The keyword options passed to ``apply``/``apply_async``;
+            mutated in place to remove ``headers`` (re-supplied by the caller).
+
+    Returns:
+        The merged headers dict to forward as ``headers=``.
+    """
+    headers = dict(options.pop("headers", None) or {})
+    for key, value in _capture().items():
+        headers.setdefault(key, value)
+    return headers
+
+
+class RLSTask(Task):
+    """Celery task base that carries the RLS context from caller to worker.
+
+    On enqueue (``apply_async`` on a real broker, or ``apply`` in eager mode and
+    for canvas steps) the active tenant/admin context is captured into the task
+    headers. On the worker, :meth:`__call__` reads those headers and runs the
+    body inside the matching ``tenant_context()`` / ``admin_context()``, which
+    restores cleanly on both success and exception.
+
+    Prefer the :func:`rls_task` decorator; subclass or pass
+    ``shared_task(base=RLSTask)`` only when you need a custom base.
+
+    Attributes:
+        rls_require_context: When ``True``, a task that arrives without any
+            propagated context raises :class:`NoTenantContextError` instead of
+            running unscoped. Defaults to ``False`` (fail-closed: run with no
+            context, so RLS returns zero rows). Set it per task for jobs that
+            must never run tenant-blind.
+    """
+
+    abstract = True
+    rls_require_context: bool = False
+
+    def apply_async(self, args: Any = None, kwargs: Any = None, **options: Any) -> Any:
+        """Capture the active context into headers, then enqueue normally."""
+        merged_headers = _merge_headers(options)  # also pops "headers" from options
+        return super().apply_async(args, kwargs, headers=merged_headers, **options)
+
+    def apply(self, args: Any = None, kwargs: Any = None, **options: Any) -> Any:
+        """Capture context for eager execution and for canvas steps.
+
+        Eager mode and canvas (chain/group) dispatch call ``apply`` directly
+        rather than going through ``apply_async``, so the capture is wired in
+        here as well to cover those paths.
+        """
+        merged_headers = _merge_headers(options)  # also pops "headers" from options
+        return super().apply(args, kwargs, headers=merged_headers, **options)
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        """Restore the propagated RLS context around the task body."""
+        tenant_id, is_admin = _request_context(self.request)
+        if tenant_id is not None:
+            with tenant_context(tenant_id):
+                return super().__call__(*args, **kwargs)
+        if is_admin:
+            with admin_context():
+                return super().__call__(*args, **kwargs)
+        if self.rls_require_context:
+            msg = f"Task {self.name!r} ran without an RLS context."
+            raise NoTenantContextError(msg, hint=HINT_NO_CONTEXT)
+        return super().__call__(*args, **kwargs)
+
+
+def rls_task(*args: Any, **options: Any) -> Any:
+    """Define a Celery task that propagates the RLS context. Like ``shared_task``.
+
+    A thin wrapper over :func:`celery.shared_task` that defaults ``base`` to
+    :class:`RLSTask`. Use it exactly as you would ``shared_task`` -- bare or with
+    options::
+
+        from django_rls_tenants.contrib.celery import rls_task
+
+        @rls_task
+        def reindex(): ...
+
+        @rls_task(bind=True, max_retries=3)
+        def sync(self): ...
+
+    Enqueue inside an RLS context and the worker runs the body scoped to the same
+    tenant::
+
+        with tenant_context(tenant.pk):
+            reindex.delay()          # runs on the worker under tenant_context(tenant.pk)
+
+    Args:
+        *args: Forwarded to ``shared_task`` (e.g. the decorated function).
+        **options: Forwarded to ``shared_task``. ``base`` defaults to
+            :class:`RLSTask`; pass your own ``base`` (a ``RLSTask`` subclass) to
+            override -- for example to set ``rls_require_context = True``.
+
+    Returns:
+        The shared task, or a decorator when called with options.
+    """
+    options.setdefault("base", RLSTask)
+    return shared_task(*args, **options)
+
+
+# ---------------------------------------------------------------------------
+# Signal-based escape hatch (opt-in via install())
+# ---------------------------------------------------------------------------
+
+_DISPATCH_UID = "django_rls_tenants.contrib.celery"
+
+# Active context managers entered by the prerun signal, keyed by task id. A list
+# (stack) tolerates a task id re-entering before its first run unwinds; postrun
+# pops the matching entry. Only populated when install() is active.
+_signal_contexts: dict[str, list[AbstractContextManager[None]]] = {}
+
+
+def _before_task_publish(
+    headers: dict[str, Any] | None = None,
+    **_: Any,
+) -> None:
+    """Inject the active RLS context into a task's outgoing headers (publish side).
+
+    Connected by :func:`install`. Mirrors :meth:`RLSTask.apply_async` for tasks
+    that are not :class:`RLSTask` instances. Protocol v1 has no ``headers``
+    mapping, so there is nothing to do then.
+    """
+    if headers is None:
+        return
+    for key, value in _capture().items():
+        headers.setdefault(key, value)
+
+
+def _safe_exit(context: AbstractContextManager[None]) -> None:
+    """Exit a propagated context, logging instead of raising on teardown failure.
+
+    The signal-path teardown runs inside Celery's signal dispatcher, so a
+    GUC-restore error (for example a dropped connection) must not escape into
+    it. The context managers reset their ``ContextVar`` state *before* the GUC
+    statement that might fail, so swallowing here never strands the in-process
+    tenant id -- at worst a stale GUC remains on a connection that is about to
+    be recycled.
+    """
+    try:
+        context.__exit__(None, None, None)
+    except Exception:
+        logger.exception("django-rls-tenants: failed to exit propagated RLS context")
+
+
+def _task_prerun(
+    task_id: str | None = None,
+    task: Any = None,
+    **_: Any,
+) -> None:
+    """Enter the propagated RLS context before a task body runs (worker side).
+
+    Connected by :func:`install`. :class:`RLSTask` instances manage their own
+    context in :meth:`RLSTask.__call__`, so they are skipped here to avoid
+    entering it twice.
+    """
+    if task_id is None or isinstance(task, RLSTask):
+        return
+    tenant_id, is_admin = _request_context(getattr(task, "request", None))
+    if tenant_id is not None:
+        context: AbstractContextManager[None] = tenant_context(tenant_id)
+    elif is_admin:
+        context = admin_context()
+    else:
+        return
+    try:
+        context.__enter__()
+    except Exception:
+        logger.exception(
+            "django-rls-tenants: failed to enter propagated RLS context for task %s; "
+            "it runs without a tenant context (fail-closed)",
+            task_id,
+        )
+        return
+    _signal_contexts.setdefault(task_id, []).append(context)
+
+
+def _task_postrun(task_id: str | None = None, **_: Any) -> None:
+    """Exit the context entered by :func:`_task_prerun` (worker side)."""
+    if task_id is None:
+        return
+    stack = _signal_contexts.get(task_id)
+    if not stack:
+        return
+    context = stack.pop()
+    if not stack:
+        del _signal_contexts[task_id]
+    _safe_exit(context)
+
+
+def install() -> None:
+    """Globally propagate RLS context for *all* Celery tasks, via signals.
+
+    Connects ``before_task_publish`` (capture into headers) and
+    ``task_prerun`` / ``task_postrun`` (restore around the body) so context flows
+    even for tasks that are not based on :class:`RLSTask`. Use it as an escape
+    hatch for third-party or legacy tasks you cannot re-base.
+
+    Prefer :func:`rls_task` / :class:`RLSTask` where you can: they restore the
+    context for the whole body including its own ``apply_async`` calls, are
+    scoped per task, and need no global wiring. ``install()`` and the base class
+    compose safely -- ``RLSTask`` instances are skipped by the signal handlers.
+
+    Call it once during startup (for example in your Celery app module). It is
+    idempotent: a repeated call does not double-connect. Reverse it with
+    :func:`uninstall`.
+    """
+    before_task_publish.connect(_before_task_publish, dispatch_uid=_DISPATCH_UID, weak=False)
+    task_prerun.connect(_task_prerun, dispatch_uid=_DISPATCH_UID, weak=False)
+    task_postrun.connect(_task_postrun, dispatch_uid=_DISPATCH_UID, weak=False)
+
+
+def uninstall() -> None:
+    """Disconnect the signal handlers connected by :func:`install`.
+
+    Idempotent: safe to call when :func:`install` was never called. Does not
+    affect tasks based on :class:`RLSTask`, which never relied on the signals.
+    Any contexts still open from :func:`_task_prerun` are exited here as a
+    best-effort cleanup so a stale context cannot leak into the next task.
+
+    Warning:
+        Do not call this while tasks are still executing on *other* threads. A
+        ``ContextVar`` token can only be reset on the thread that created it, and
+        Django database connections are thread-local, so this cleanup only
+        unwinds contexts entered on the calling thread -- an in-flight task on a
+        worker thread keeps its context until it finishes. Call ``uninstall()``
+        at shutdown, or from the worker thread between tasks.
+    """
+    before_task_publish.disconnect(_before_task_publish, dispatch_uid=_DISPATCH_UID)
+    task_prerun.disconnect(_task_prerun, dispatch_uid=_DISPATCH_UID)
+    task_postrun.disconnect(_task_postrun, dispatch_uid=_DISPATCH_UID)
+    for stack in list(_signal_contexts.values()):
+        for context in reversed(stack):
+            _safe_exit(context)
+    _signal_contexts.clear()

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -28,6 +28,35 @@
     poetry add django-rls-tenants
     ```
 
+## Optional Extras
+
+### Celery
+
+Native Celery integration (`@rls_task`, `RLSTask`, `install()`) ships behind the
+`celery` extra, so Celery itself stays an optional dependency:
+
+=== "pip"
+
+    ```bash
+    pip install "django-rls-tenants[celery]"
+    ```
+
+=== "uv"
+
+    ```bash
+    uv add "django-rls-tenants[celery]"
+    ```
+
+=== "poetry"
+
+    ```bash
+    poetry add "django-rls-tenants[celery]"
+    ```
+
+Without the extra the core library is unaffected; importing
+`django_rls_tenants.contrib.celery` without Celery installed raises a clear
+`ImportError`. See the [Celery Tasks guide](../guides/celery-tasks.md).
+
 ## Add to INSTALLED_APPS
 
 ```python title="settings.py"

--- a/docs/guides/celery-tasks.md
+++ b/docs/guides/celery-tasks.md
@@ -1,17 +1,264 @@
 # Celery Tasks
 
 Celery tasks run outside the request/response cycle, so `RLSTenantMiddleware`
-never sets the RLS context for them. Each task must establish its own context
-explicitly -- otherwise, queries against RLS-protected models return zero rows
-(fail-closed), or raise `NoTenantContextError` when `STRICT_MODE` is enabled.
+never sets the RLS context for them. A task that queries an RLS-protected model
+without a context gets zero rows (fail-closed), or raises `NoTenantContextError`
+when `STRICT_MODE` is enabled.
+
+django-rls-tenants ships a **native Celery integration** that captures the
+active tenant (or admin) context when a task is enqueued and restores it on the
+worker before the task body runs — so you don't have to thread `tenant_id`
+through every task by hand. The [manual pattern](#without-the-extra) is still
+available if you'd rather not add the dependency.
+
+!!! info "Sync only"
+    v1.3.0 is synchronous-only. The context is restored on the worker thread,
+    which an event loop does not propagate into coroutines, so `async def` task
+    bodies are **not** supported. Keep RLS-touching task bodies synchronous.
+
+## Install
+
+The integration lives behind the `celery` extra, keeping Celery an optional
+dependency:
+
+```bash
+pip install "django-rls-tenants[celery]"
+```
+
+Import it from `django_rls_tenants.contrib.celery` (never from the top-level
+package — that stays Celery-free):
+
+```python
+from django_rls_tenants.contrib.celery import rls_task
+```
+
+## `@rls_task`
+
+`@rls_task` is a drop-in replacement for `@shared_task`. Use it exactly the same
+way; the only difference is that the task now carries the RLS context across the
+enqueue → worker boundary:
+
+```python
+from django_rls_tenants.contrib.celery import rls_task
+
+
+@rls_task
+def process_orders() -> None:
+    for order in Order.objects.all():   # scoped to the enqueuing tenant
+        ...
+```
+
+Enqueue it from inside a context — usually the request context set by
+`RLSTenantMiddleware`, or an explicit `tenant_context()`:
+
+```python
+# In a view, with the middleware active:
+process_orders.delay()        # captures request.user's tenant
+
+# Or explicitly:
+with tenant_context(tenant.pk):
+    process_orders.delay()    # worker runs the body under tenant_context(tenant.pk)
+```
+
+Notice there is **no `tenant_id` argument**. The context is captured
+automatically, so the task signature stays about the work, not the plumbing.
+
+!!! tip
+    `@rls_task` accepts every `shared_task` option, bound tasks included:
+
+    ```python
+    @rls_task(bind=True, max_retries=3)
+    def sync(self) -> None:
+        ...
+    ```
+
+### How it works
+
+On enqueue (`delay` / `apply_async`), the active context is serialised into the
+task's message **headers** (`rls_tenant_id`, `rls_admin`). On the worker, the
+task base class reads those headers and runs the body inside the matching
+`tenant_context()` / `admin_context()`, which restores cleanly whether the body
+returns or raises. An explicitly-passed header always wins over the captured
+value, so you can override it per call if you ever need to.
+
+If no context is active when the task is enqueued, nothing is captured and the
+task runs unscoped (fail-closed) — unless you opt into
+[`rls_require_context`](#requiring-a-context).
+
+## The `RLSTask` base class
+
+`@rls_task` is sugar for `shared_task(base=RLSTask)`. Use the base class
+directly when you need a custom base — for example to set defaults shared by
+several tasks:
+
+```python
+from celery import shared_task
+from django_rls_tenants.contrib.celery import RLSTask
+
+
+@shared_task(base=RLSTask)
+def rebuild_index() -> None:
+    ...
+```
+
+## Chains and groups
+
+Context propagates through canvases (chains, groups, chords). When the worker
+finishes one step and enqueues the next, the upstream task is still the *current*
+task, so its headers are inherited even though its `tenant_context()` has already
+closed:
+
+```python
+from celery import chain
+from django_rls_tenants.contrib.celery import rls_task
+
+
+@rls_task
+def extract(): ...
+
+
+@rls_task
+def load(result): ...
+
+
+with tenant_context(tenant.pk):
+    chain(extract.s(), load.s()).apply_async()   # both steps run under tenant.pk
+```
+
+!!! warning "Every step must be an RLS task"
+    Propagation only works for steps that use `@rls_task` / `RLSTask` (or the
+    [`install()`](#global-escape-hatch-install) hook). A plain `@shared_task`
+    in the middle of a chain breaks the context for itself **and** every step
+    after it.
+
+## Requiring a context
+
+By default a task with no propagated context runs unscoped (RLS then returns
+zero rows). For jobs that must never run tenant-blind, set `rls_require_context`
+on a `RLSTask` subclass to fail fast instead:
+
+```python
+from celery import shared_task
+from django_rls_tenants.contrib.celery import RLSTask
+
+
+class StrictTask(RLSTask):
+    rls_require_context = True
+
+
+@shared_task(base=StrictTask)
+def charge_invoices() -> None:
+    ...
+```
+
+Enqueued without a context, `charge_invoices` raises `NoTenantContextError`
+(carrying a `Hint:` on how to fix it) instead of running.
+
+## Cross-tenant and scheduled tasks
+
+For periodic (beat) tasks that operate across all tenants, enqueue under
+`admin_context()` — it propagates as admin mode — then re-enter
+`tenant_context()` for each tenant inside the body:
+
+```python
+from django_rls_tenants import admin_context, tenant_context
+from django_rls_tenants.contrib.celery import rls_task
+
+
+@rls_task
+def nightly_billing() -> None:
+    with admin_context():
+        tenant_ids = list(Tenant.objects.values_list("pk", flat=True))
+    for tenant_id in tenant_ids:
+        with tenant_context(tenant_id):
+            _bill_one_tenant()
+```
+
+!!! warning
+    `admin_context()` bypasses tenant isolation entirely — it sees every
+    tenant's data. Keep its body minimal: fetch the tenant list, then scope each
+    operation back down with `tenant_context()`.
+
+## Global escape hatch: `install()`
+
+`@rls_task` / `RLSTask` is the recommended API, but you cannot always re-base a
+task onto it (third-party tasks, a large legacy code base). `install()` wires the
+same capture/restore globally via Celery signals
+(`before_task_publish` + `task_prerun` / `task_postrun`), so context flows for
+**all** tasks regardless of their base class:
+
+```python
+# In your Celery app module, once at startup:
+from django_rls_tenants.contrib.celery import install
+
+install()
+```
+
+It is idempotent (a repeated call does not double-wire) and reversible with
+`uninstall()`. `install()` and the base class compose safely — `RLSTask`
+instances keep managing their own context and are skipped by the signal
+handlers, so there is no double-entry.
 
 !!! note
-    Native Celery integration (automatic context propagation without manual
-    wiring) is planned for v1.3.0. This page documents the interim pattern.
+    The signal hook fires on a real broker. In eager mode
+    (`task_always_eager`), `before_task_publish` does not run, so prefer
+    `@rls_task` / `RLSTask` when you want context propagation in eager-mode
+    tests.
 
-## Core Pattern
+!!! warning "Call `uninstall()` at shutdown, not mid-flight"
+    `uninstall()` can only unwind contexts entered on the calling thread (a
+    `ContextVar` token is thread-bound and database connections are
+    thread-local). Calling it while tasks are still running on worker threads
+    leaves those in-flight contexts to unwind on their own thread when the task
+    finishes — so disconnect at shutdown, or from the worker thread between
+    tasks.
 
-Pass `tenant_id` as a task argument and wrap the task body in `tenant_context()`:
+## Multi-database tasks
+
+The propagated context is restored on the **`default`** database alias only.
+`RLSTenantMiddleware` sets the RLS GUC on every alias in
+`RLS_TENANTS["DATABASES"]`, but the task integration restores a single alias, so
+queries a task runs against any *other* alias are **not** scoped unless you
+re-enter the context for that alias yourself. Pass `using="..."` to the context
+manager inside the task body to scope queries on a specific alias:
+
+```python
+@rls_task
+def replicate() -> None:
+    with tenant_context(get_current_tenant_id(), using="replica"):
+        Order.objects.using("replica").all()
+```
+
+!!! warning "Non-default aliases are not auto-scoped"
+    A task body that queries a replica or secondary database without an explicit
+    `tenant_context(..., using="<alias>")` runs **unscoped** on that alias (RLS
+    then returns zero rows, or every row in admin mode). Wrap every non-default
+    alias the task touches, as shown above.
+
+See [Context Managers](context-managers.md#multi-database-support) for details.
+
+## Security model
+
+A few properties are worth keeping in mind for a multi-tenant deployment:
+
+- **Task headers are trusted.** `rls_tenant_id` / `rls_admin` travel in the task
+  message, so anything that can publish to your broker can ask a worker to run
+  under any tenant — or as a cross-tenant admin (`rls_admin: true`). This is the
+  same trust Celery already places in task arguments; treat broker credentials
+  as security-sensitive and keep the broker off untrusted networks.
+- **Admin context flows down a canvas.** A task running under `admin_context()`
+  propagates admin mode to the steps it enqueues (chain / group / chord links),
+  because each downstream step inherits the upstream task's headers. If you link
+  an unrelated task to an admin task it inherits admin too — pass an explicit
+  `headers={"rls_tenant_id": tenant_id}` to scope it down, or don't enqueue it
+  from inside an admin context.
+
+## Without the extra
+
+If you'd rather not install Celery as a managed dependency of this library, you
+can keep the context wiring in your own code. Pass the tenant **id** (never a
+model instance — Celery serialises arguments, and a serialised instance is
+wasteful and can go stale) and wrap the body in `tenant_context()`:
 
 ```python
 from celery import shared_task
@@ -25,60 +272,13 @@ def process_orders(tenant_id: int) -> None:
             ...
 ```
 
-!!! warning
-    Pass the tenant **id** (an `int` or `str`), never a model instance. Celery
-    serialises task arguments, and a serialised model instance is both wasteful
-    and can go stale before the task executes.
-
-!!! warning
-    Every task that queries RLS-protected models must set a context. A task that
-    forgets gets zero rows (fail-closed), or raises `NoTenantContextError` when
-    `STRICT_MODE=True`.
-
-## Enqueuing from a Request
-
-The current tenant's ID is typically available as `request.user.rls_tenant_id`:
-
 ```python
-# In a view:
+# Enqueue from a view:
 process_orders.delay(request.user.rls_tenant_id)
 ```
 
-## Cross-Tenant and Scheduled Tasks
-
-For periodic (beat) tasks that operate across all tenants, use `admin_context()`
-to read the tenant list, then re-enter `tenant_context()` for each tenant:
-
-```python
-from celery import shared_task
-from django_rls_tenants import admin_context, tenant_context
-
-
-@shared_task
-def nightly_billing() -> None:
-    with admin_context():
-        tenants = Tenant.objects.all()
-        for tenant in tenants:
-            with tenant_context(tenant_id=tenant.pk):
-                _process_orders(tenant)
-
-
-def _process_orders(tenant: Tenant) -> None:
-    orders = Order.objects.filter(status="pending")
-    for order in orders:
-        order.process()
-```
-
-!!! warning
-    `admin_context()` bypasses tenant isolation entirely -- it sees every
-    tenant's data. Keep its body minimal: use it only to fetch the tenant list,
-    then scope each operation back down with `tenant_context()`. Never mix in
-    user-supplied tenant filtering inside `admin_context()`.
-
-## Reusable Decorator
-
-To avoid repeating the `with tenant_context(tenant_id):` block in every task,
-write a thin decorator that reads `tenant_id` from the first argument:
+To avoid repeating the `with` block, a thin decorator that reads `tenant_id`
+from the first argument works for unbound tasks:
 
 ```python
 import functools
@@ -86,46 +286,27 @@ from django_rls_tenants import tenant_context
 
 
 def with_tenant_context(func):
-    """Decorator that opens tenant_context(tenant_id) around the task body.
-
-    Expects ``tenant_id`` as the first positional argument.
-    """
     @functools.wraps(func)
     def wrapper(tenant_id, *args, **kwargs):
         with tenant_context(tenant_id):
             return func(tenant_id, *args, **kwargs)
     return wrapper
-```
-
-```python
-from celery import shared_task
 
 
 @shared_task
 @with_tenant_context
 def process_orders(tenant_id: int) -> None:
-    for order in Order.objects.all():   # already scoped by decorator
+    for order in Order.objects.all():   # already scoped by the decorator
         ...
 ```
 
 !!! warning
-    This decorator assumes `tenant_id` is the **first positional argument**, so it
-    does not work with bound tasks (`@shared_task(bind=True)`) -- there Celery passes
-    the task instance first, and `tenant_id` would receive `self`. For bound tasks,
-    keep the explicit `with tenant_context(tenant_id):` block in the task body instead.
-
-!!! tip
-    In multi-database setups, pass `using="..."` to `tenant_context()` to scope
-    queries on a specific database alias:
-
-    ```python
-    with tenant_context(tenant_id, using="replica"):
-        orders = Order.objects.using("replica").all()
-    ```
-
-    See [Context Managers](context-managers.md#multi-database-support) for details.
+    This decorator assumes `tenant_id` is the **first positional argument**, so
+    it does not work with bound tasks (`@shared_task(bind=True)`) — there Celery
+    passes the task instance first. For bound tasks, keep the explicit
+    `with tenant_context(tenant_id):` block in the body.
 
 !!! note
-    See [Context Managers](context-managers.md) for the full `tenant_context()` and
-    `admin_context()` API -- including nesting, debug logging, and strict mode
-    interaction. Native Celery integration is on the v1.3.0 roadmap.
+    See [Context Managers](context-managers.md) for the full `tenant_context()`
+    and `admin_context()` API — nesting, debug logging, and strict-mode
+    interaction.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -165,3 +165,25 @@ Helpers for scoping hand-written SQL to the current tenant. See the
 ::: django_rls_tenants.tenants.testing.assert_rls_policy_exists
 
 ::: django_rls_tenants.tenants.testing.assert_rls_blocks_without_context
+
+---
+
+## Contrib
+
+Optional integrations with third-party libraries. These are **not** re-exported
+from the top-level package; import them from their module.
+
+### Celery
+
+Native Celery integration. Requires the `celery` extra
+(`pip install django-rls-tenants[celery]`); import from
+`django_rls_tenants.contrib.celery`. See the [Celery Tasks guide](../guides/celery-tasks.md)
+for usage, chains/groups, and the `install()` escape hatch.
+
+::: django_rls_tenants.contrib.celery.rls_task
+
+::: django_rls_tenants.contrib.celery.RLSTask
+
+::: django_rls_tenants.contrib.celery.install
+
+::: django_rls_tenants.contrib.celery.uninstall

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,13 @@ dependencies = [
     "django>=4.2",
 ]
 
+[project.optional-dependencies]
+# Native Celery integration (contrib.celery): @rls_task / RLSTask / install().
+# Optional -- the core library never imports celery.
+celery = [
+    "celery>=5.3",
+]
+
 [project.urls]
 Homepage = "https://github.com/dvoraj75/django-rls-tenants"
 Documentation = "https://dvoraj75.github.io/django-rls-tenants/"
@@ -77,11 +84,14 @@ test = [
     "pytest-cov>=6.0",
     "coverage[toml]>=7.0",
     "psycopg2-binary>=2.9",
+    "celery>=5.3",
 ]
 docs = [
     "mkdocs>=1.6",
     "mkdocs-material>=9.5",
     "mkdocstrings[python]>=0.27",
+    # mkdocstrings imports contrib.celery to render its API reference.
+    "celery>=5.3",
 ]
 
 # ---------------------------------------------------------------------------
@@ -190,6 +200,21 @@ mypy_path = "."
 [[tool.mypy.overrides]]
 module = "tests.*"
 disallow_untyped_defs = false
+
+# Celery is an optional dependency and ships no type information. It is not
+# installed in the lint/type-check job (which syncs only the ``dev`` group), so
+# tell mypy not to error on the missing stubs.
+[[tool.mypy.overrides]]
+module = "celery.*"
+ignore_missing_imports = true
+
+# ``contrib.celery`` subclasses celery's ``Task``, which is typed as ``Any``
+# here (celery ships no stubs and is absent from the lint env). Relax just the
+# subclassing-any check for this one module; everything else stays strict and
+# the module is fully annotated.
+[[tool.mypy.overrides]]
+module = "django_rls_tenants.contrib.celery"
+disallow_subclassing_any = false
 
 [tool.django-stubs]
 django_settings_module = "tests.settings"

--- a/tests/test_contrib/test_celery.py
+++ b/tests/test_contrib/test_celery.py
@@ -1,0 +1,587 @@
+"""Tests for django_rls_tenants.contrib.celery (issue #32).
+
+These run Celery in eager mode (``task_always_eager``), so no broker or worker is
+needed: a task executes inline when enqueued, while still exercising the real
+header capture (``apply_async`` / ``apply``) and restore (``__call__``) paths.
+
+The suite splits into:
+
+* pure-logic unit tests for ``_capture`` / ``_request_context`` / ``_merge_headers``
+  and the signal handlers (no row access);
+* eager round-trip tests proving an ``@rls_task`` body runs under the propagated
+  ``tenant_context()`` / ``admin_context()``, including across a chain and a group;
+* one ``@pytest.mark.integration`` test proving end-to-end row isolation under
+  ``enforce_rls``.
+
+Entering a real ``tenant_context()`` issues ``set_config`` GUC statements, so the
+tests that restore a context need a database connection (the autouse cleanup
+fixture in ``tests/conftest.py`` already pulls in ``db``).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from celery import Celery, chain, chord, group, shared_task
+from celery.signals import before_task_publish
+
+from django_rls_tenants.contrib import celery as celery_mod
+from django_rls_tenants.contrib.celery import (
+    _ADMIN_HEADER,
+    _TENANT_HEADER,
+    RLSTask,
+    _capture,
+    _merge_headers,
+    _request_context,
+    install,
+    rls_task,
+    uninstall,
+)
+from django_rls_tenants.exceptions import NoTenantContextError
+from django_rls_tenants.tenants.context import admin_context, tenant_context
+from django_rls_tenants.tenants.state import (
+    get_current_tenant_id,
+    get_rls_context_active,
+    set_current_tenant_id,
+    set_rls_context_active,
+)
+
+# A dedicated eager Celery app. ``task_eager_propagates`` re-raises task
+# exceptions to the caller (so a failing task surfaces in the test);
+# ``task_store_eager_result`` makes ``.get()`` return the value.
+celery_app = Celery("test_rls_tenants")
+celery_app.conf.update(
+    task_always_eager=True,
+    task_eager_propagates=True,
+    task_store_eager_result=True,
+    broker_url="memory://",
+    result_backend="cache+memory://",
+)
+celery_app.set_current()
+
+
+@rls_task
+def report_context() -> tuple[object, bool]:
+    """Return the RLS context the worker established for this task."""
+    return get_current_tenant_id(), get_rls_context_active()
+
+
+@rls_task
+def seed_task() -> object:
+    """First step of a canvas; returns the active tenant id."""
+    return get_current_tenant_id()
+
+
+@rls_task
+def follow_task(_prev: object = None) -> object:
+    """Downstream canvas step; returns the tenant id it inherited."""
+    return get_current_tenant_id()
+
+
+class StrictRLSTask(RLSTask):
+    """RLSTask variant that refuses to run without a propagated context."""
+
+    rls_require_context = True
+
+
+@shared_task(base=StrictRLSTask)
+def strict_task() -> str:
+    """Task that must always run inside an RLS context."""
+    return "ran"
+
+
+@rls_task
+def fetch_products() -> list[str]:
+    """Return the products visible to the worker (RLS-scoped)."""
+    from tests.test_app.models import Order  # noqa: PLC0415
+
+    return sorted(Order.objects.values_list("product", flat=True))
+
+
+@rls_task(bind=True)
+def report_headers(self) -> dict[str, object]:
+    """Return the RLS headers this task was enqueued with.
+
+    Bound so it can read ``self.request.headers``. Used to inspect the
+    *propagated header* directly, which proves the capture path independently
+    of the body's observed context (eager mode masks the latter).
+    """
+    headers = self.request.headers or {}
+    return {_TENANT_HEADER: headers.get(_TENANT_HEADER), _ADMIN_HEADER: headers.get(_ADMIN_HEADER)}
+
+
+# ---------------------------------------------------------------------------
+# _capture()
+# ---------------------------------------------------------------------------
+
+
+class TestCapture:
+    """_capture() reads live context first, then inherits from the running task."""
+
+    def test_live_tenant_context(self):
+        """A live tenant context is captured as a tenant header."""
+        set_current_tenant_id(7)
+        assert _capture() == {_TENANT_HEADER: 7, _ADMIN_HEADER: False}
+
+    def test_live_admin_context(self):
+        """A live admin context (active flag, no tenant) is captured as admin."""
+        set_current_tenant_id(None)
+        set_rls_context_active(True)
+        assert _capture() == {_TENANT_HEADER: None, _ADMIN_HEADER: True}
+
+    def test_no_context_is_empty(self):
+        """No context and no running task captures nothing (fail-closed)."""
+        assert _capture() == {}
+
+    def test_inherits_tenant_from_current_task(self, monkeypatch):
+        """With no live context, headers are inherited from the running task."""
+        fake = SimpleNamespace(
+            request=SimpleNamespace(headers={_TENANT_HEADER: 42, _ADMIN_HEADER: False})
+        )
+        monkeypatch.setattr(celery_mod, "current_task", fake)
+        assert _capture() == {_TENANT_HEADER: 42, _ADMIN_HEADER: False}
+
+    def test_inherits_admin_from_current_task(self, monkeypatch):
+        """Admin context propagates through the current-task fallback too."""
+        fake = SimpleNamespace(
+            request=SimpleNamespace(headers={_TENANT_HEADER: None, _ADMIN_HEADER: True})
+        )
+        monkeypatch.setattr(celery_mod, "current_task", fake)
+        assert _capture() == {_TENANT_HEADER: None, _ADMIN_HEADER: True}
+
+    def test_current_task_without_rls_headers(self, monkeypatch):
+        """A running task whose headers lack RLS keys contributes nothing."""
+        fake = SimpleNamespace(request=SimpleNamespace(headers={"other": 1}))
+        monkeypatch.setattr(celery_mod, "current_task", fake)
+        assert _capture() == {}
+
+    def test_live_context_beats_current_task(self, monkeypatch):
+        """A live tenant context wins over the running task's headers."""
+        set_current_tenant_id(7)
+        fake = SimpleNamespace(request=SimpleNamespace(headers={_TENANT_HEADER: 42}))
+        monkeypatch.setattr(celery_mod, "current_task", fake)
+        assert _capture() == {_TENANT_HEADER: 7, _ADMIN_HEADER: False}
+
+    def test_zero_tenant_id_is_captured(self):
+        """tenant_id=0 is falsy but not None -- it must be captured, not skipped."""
+        set_current_tenant_id(0)
+        assert _capture() == {_TENANT_HEADER: 0, _ADMIN_HEADER: False}
+
+
+# ---------------------------------------------------------------------------
+# _request_context()
+# ---------------------------------------------------------------------------
+
+
+class TestRequestContext:
+    """_request_context() parses the task request's headers."""
+
+    def test_reads_tenant_from_headers(self):
+        req = SimpleNamespace(headers={_TENANT_HEADER: 5, _ADMIN_HEADER: False})
+        assert _request_context(req) == (5, False)
+
+    def test_reads_admin_from_headers(self):
+        req = SimpleNamespace(headers={_TENANT_HEADER: None, _ADMIN_HEADER: True})
+        assert _request_context(req) == (None, True)
+
+    def test_headers_without_rls_keys(self):
+        """Headers present but missing the tenant key -> no context."""
+        req = SimpleNamespace(headers={"other": 1})
+        assert _request_context(req) == (None, False)
+
+    def test_falls_back_to_top_level_attributes(self):
+        """When headers is not a dict, top-level request attrs are used."""
+        req = SimpleNamespace(headers=None, rls_tenant_id=9, rls_admin=False)
+        assert _request_context(req) == (9, False)
+
+    def test_none_request(self):
+        assert _request_context(None) == (None, False)
+
+    def test_tenant_header_without_admin_key_defaults_admin_false(self):
+        """A tenant header with no admin key defaults is_admin to False."""
+        req = SimpleNamespace(headers={_TENANT_HEADER: 5})
+        assert _request_context(req) == (5, False)
+
+
+# ---------------------------------------------------------------------------
+# _merge_headers()
+# ---------------------------------------------------------------------------
+
+
+class TestMergeHeaders:
+    """_merge_headers() folds the captured context into outgoing headers."""
+
+    def test_no_context_returns_empty(self):
+        options = {}
+        assert _merge_headers(options) == {}
+
+    def test_injects_live_tenant(self):
+        set_current_tenant_id(7)
+        assert _merge_headers({}) == {_TENANT_HEADER: 7, _ADMIN_HEADER: False}
+
+    def test_does_not_clobber_explicit_header(self):
+        """An explicitly-passed header is never overwritten by capture."""
+        set_current_tenant_id(7)
+        options = {"headers": {_TENANT_HEADER: 99}}
+        assert _merge_headers(options)[_TENANT_HEADER] == 99
+
+    def test_pops_headers_and_keeps_other_options(self):
+        """``headers`` is removed from options; other options are untouched."""
+        options = {"headers": {"x": 1}, "countdown": 5}
+        merged = _merge_headers(options)
+        assert "headers" not in options
+        assert options == {"countdown": 5}
+        assert merged["x"] == 1
+
+
+# ---------------------------------------------------------------------------
+# rls_task() / RLSTask base wiring
+# ---------------------------------------------------------------------------
+
+
+class TestRlsTaskDecorator:
+    """rls_task() is shared_task with base defaulted to RLSTask."""
+
+    def test_task_uses_rlstask_base(self):
+        assert isinstance(report_context, RLSTask)
+
+    def test_explicit_base_is_respected(self):
+        """A custom base (StrictRLSTask) passes through rls_task's setdefault."""
+        assert isinstance(strict_task, StrictRLSTask)
+        assert strict_task.rls_require_context is True
+
+    def test_default_does_not_require_context(self):
+        assert report_context.rls_require_context is False
+
+
+# ---------------------------------------------------------------------------
+# Capture wiring: apply_async / apply fold the live context into the headers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestCaptureWiring:
+    """apply_async/apply actually write the live context into the message headers.
+
+    Eager mode runs the body synchronously inside the enqueuing context, so a
+    test that only checks the body's observed tenant cannot distinguish capture
+    from the outer ``tenant_context`` leaking in. Inspecting the propagated
+    header (via a bound task reading ``self.request.headers``) isolates the
+    capture path: the header is present only because apply_async/apply ran it.
+    """
+
+    def test_apply_async_captures_live_tenant_into_headers(self, tenant_a):
+        """Enqueuing inside a tenant context writes the tenant header."""
+        with tenant_context(tenant_a.pk):
+            headers = report_headers.delay().get()
+        assert headers == {_TENANT_HEADER: tenant_a.pk, _ADMIN_HEADER: False}
+
+    def test_apply_async_captures_admin_into_headers(self):
+        """Enqueuing inside an admin context writes the admin header."""
+        with admin_context():
+            headers = report_headers.delay().get()
+        assert headers == {_TENANT_HEADER: None, _ADMIN_HEADER: True}
+
+    def test_explicit_header_survives_eager_double_capture(self):
+        """Eager apply_async re-invokes apply; an explicit header must survive both."""
+        headers = report_headers.apply_async(headers={_TENANT_HEADER: 99}).get()
+        assert headers[_TENANT_HEADER] == 99
+
+    def test_zero_tenant_id_enters_tenant_context(self):
+        """A 0 tenant header enters tenant_context(0), not admin/unscoped."""
+        result = report_context.apply_async(
+            headers={_TENANT_HEADER: 0, _ADMIN_HEADER: False}
+        ).get()
+        assert result == (0, True)
+
+
+# ---------------------------------------------------------------------------
+# Eager round-trip: __call__ restores the context
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestEagerRoundTrip:
+    """An enqueued @rls_task body runs under the propagated context."""
+
+    def test_restores_tenant_from_explicit_header(self, tenant_a):
+        """No outer context: the body is scoped purely from the task header."""
+        assert get_current_tenant_id() is None
+        result = report_context.apply_async(headers={_TENANT_HEADER: tenant_a.pk}).get()
+        assert result == (tenant_a.pk, True)
+        assert get_current_tenant_id() is None  # restored on exit
+
+    def test_restores_admin_from_header(self):
+        """A header marking admin context runs the body in admin mode."""
+        result = report_context.apply_async(
+            headers={_TENANT_HEADER: None, _ADMIN_HEADER: True}
+        ).get()
+        assert result == (None, True)
+        assert get_rls_context_active() is False
+
+    def test_captures_live_context_on_enqueue(self, tenant_a):
+        """Enqueuing inside tenant_context() scopes the worker body to it."""
+        with tenant_context(tenant_a.pk):
+            result = report_context.delay().get()
+        assert result == (tenant_a.pk, True)
+
+    def test_no_context_runs_unscoped(self):
+        """Without context (and without rls_require_context) the body just runs."""
+        result = report_context.delay().get()
+        assert result == (None, False)
+
+    def test_exception_in_body_restores_context(self, tenant_a):
+        """A failing body still unwinds the tenant context (try/finally)."""
+
+        @rls_task
+        def boom() -> None:
+            raise ValueError("kaboom")
+
+        with pytest.raises(ValueError, match="kaboom"):
+            boom.apply_async(headers={_TENANT_HEADER: tenant_a.pk}).get()
+        assert get_current_tenant_id() is None
+
+    def test_bound_task_propagates_and_restores(self, tenant_a):
+        """@rls_task(bind=True) receives self and still runs under the context."""
+
+        @rls_task(bind=True)
+        def bound_report(self) -> tuple[object, bool, str]:
+            return get_current_tenant_id(), get_rls_context_active(), self.name
+
+        assert get_current_tenant_id() is None
+        tenant_id, active, name = bound_report.apply_async(
+            headers={_TENANT_HEADER: tenant_a.pk, _ADMIN_HEADER: False}
+        ).get()
+        assert (tenant_id, active) == (tenant_a.pk, True)
+        assert "bound_report" in name
+        assert get_current_tenant_id() is None  # restored
+
+
+# ---------------------------------------------------------------------------
+# rls_require_context fail-fast
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestRequireContext:
+    """rls_require_context=True turns a missing context into an error."""
+
+    def test_raises_without_context(self):
+        with pytest.raises(NoTenantContextError, match="without an RLS context"):
+            strict_task.apply_async().get()
+
+    def test_error_carries_hint(self):
+        from django_rls_tenants.tenants.errors import HINT_NO_CONTEXT  # noqa: PLC0415
+
+        with pytest.raises(NoTenantContextError) as exc_info:
+            strict_task.apply_async().get()
+        assert exc_info.value.hint == HINT_NO_CONTEXT
+
+    def test_runs_with_context(self, tenant_a):
+        result = strict_task.apply_async(headers={_TENANT_HEADER: tenant_a.pk}).get()
+        assert result == "ran"
+
+    def test_runs_with_admin_header(self):
+        """An admin header satisfies rls_require_context=True (does not raise)."""
+        result = strict_task.apply_async(headers={_TENANT_HEADER: None, _ADMIN_HEADER: True}).get()
+        assert result == "ran"
+
+
+# ---------------------------------------------------------------------------
+# Canvas propagation (chains / groups)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestCanvasPropagation:
+    """Context flows across chains and groups of RLS tasks."""
+
+    def test_chain_propagates_tenant(self, tenant_a):
+        with tenant_context(tenant_a.pk):
+            result = chain(seed_task.s(), follow_task.s()).apply_async()
+        assert result.get() == tenant_a.pk
+
+    def test_group_propagates_tenant(self, tenant_a):
+        with tenant_context(tenant_a.pk):
+            result = group(seed_task.s(), seed_task.s()).apply_async()
+        assert result.get() == [tenant_a.pk, tenant_a.pk]
+
+    def test_chord_propagates_tenant(self, tenant_a):
+        """A chord's callback runs under the propagated tenant context."""
+        with tenant_context(tenant_a.pk):
+            result = chord([seed_task.s(), seed_task.s()])(follow_task.s())
+        assert result.get() == tenant_a.pk
+
+
+# ---------------------------------------------------------------------------
+# Signal-based install() / uninstall()
+# ---------------------------------------------------------------------------
+
+
+class TestPublishSignal:
+    """before_task_publish injects the captured context into outgoing headers."""
+
+    def test_injects_into_headers(self):
+        set_current_tenant_id(7)
+        headers: dict[str, object] = {}
+        celery_mod._before_task_publish(headers=headers)
+        assert headers == {_TENANT_HEADER: 7, _ADMIN_HEADER: False}
+
+    def test_none_headers_is_noop(self):
+        """Protocol v1 (no headers mapping) is tolerated."""
+        set_current_tenant_id(7)
+        assert celery_mod._before_task_publish(headers=None) is None
+
+    def test_does_not_clobber_existing(self):
+        set_current_tenant_id(7)
+        headers: dict[str, object] = {_TENANT_HEADER: 99}
+        celery_mod._before_task_publish(headers=headers)
+        assert headers[_TENANT_HEADER] == 99
+
+
+@pytest.mark.django_db
+class TestPrerunPostrunSignals:
+    """task_prerun/task_postrun enter and exit the context on the worker."""
+
+    def test_enter_and_exit_tenant(self, tenant_a):
+        task = SimpleNamespace(
+            request=SimpleNamespace(headers={_TENANT_HEADER: tenant_a.pk, _ADMIN_HEADER: False})
+        )
+        assert get_current_tenant_id() is None
+        celery_mod._task_prerun(task_id="t1", task=task)
+        assert get_current_tenant_id() == tenant_a.pk
+        celery_mod._task_postrun(task_id="t1")
+        assert get_current_tenant_id() is None
+
+    def test_enter_and_exit_admin(self):
+        task = SimpleNamespace(
+            request=SimpleNamespace(headers={_TENANT_HEADER: None, _ADMIN_HEADER: True})
+        )
+        celery_mod._task_prerun(task_id="t2", task=task)
+        assert get_rls_context_active() is True
+        celery_mod._task_postrun(task_id="t2")
+        assert get_rls_context_active() is False
+
+    def test_skips_rlstask_instances(self):
+        """RLSTask tasks manage their own context, so the signal skips them."""
+        celery_mod._task_prerun(task_id="t3", task=RLSTask())
+        assert "t3" not in celery_mod._signal_contexts
+
+    def test_no_context_does_not_register(self):
+        task = SimpleNamespace(request=SimpleNamespace(headers={}))
+        celery_mod._task_prerun(task_id="t4", task=task)
+        assert "t4" not in celery_mod._signal_contexts
+
+    def test_postrun_without_prerun_is_safe(self):
+        """Postrun with no recorded context is a no-op, not an error."""
+        celery_mod._task_postrun(task_id="never-entered")
+        celery_mod._task_postrun(task_id=None)
+
+    def test_reentrant_task_id_unwinds_lifo(self, tenant_a, tenant_b):
+        """Two prerun entries under one task id unwind innermost-first."""
+        task_a = SimpleNamespace(request=SimpleNamespace(headers={_TENANT_HEADER: tenant_a.pk}))
+        task_b = SimpleNamespace(request=SimpleNamespace(headers={_TENANT_HEADER: tenant_b.pk}))
+        celery_mod._task_prerun(task_id="dup", task=task_a)
+        celery_mod._task_prerun(task_id="dup", task=task_b)
+        assert get_current_tenant_id() == tenant_b.pk
+        celery_mod._task_postrun(task_id="dup")  # pops B; A still on the stack
+        assert get_current_tenant_id() == tenant_a.pk
+        celery_mod._task_postrun(task_id="dup")  # pops A; entry removed
+        assert get_current_tenant_id() is None
+        assert "dup" not in celery_mod._signal_contexts
+
+    def test_uninstall_exits_inflight_contexts(self, tenant_a):
+        """uninstall() unwinds a context still open from prerun (no leak)."""
+        task = SimpleNamespace(request=SimpleNamespace(headers={_TENANT_HEADER: tenant_a.pk}))
+        celery_mod._task_prerun(task_id="leak", task=task)
+        assert get_current_tenant_id() == tenant_a.pk  # entered, not yet exited
+        uninstall()
+        assert get_current_tenant_id() is None  # exited by uninstall's cleanup
+        assert celery_mod._signal_contexts == {}
+
+    def test_prerun_swallows_enter_failure(self, monkeypatch):
+        """A failure entering the context is logged, not raised; task not registered."""
+
+        class BoomCtx:
+            def __enter__(self):
+                raise RuntimeError("db down")
+
+            def __exit__(self, *exc):
+                return False
+
+        monkeypatch.setattr(celery_mod, "tenant_context", lambda *a, **k: BoomCtx())
+        task = SimpleNamespace(request=SimpleNamespace(headers={_TENANT_HEADER: 5}))
+        celery_mod._task_prerun(task_id="boom", task=task)  # must not raise
+        assert "boom" not in celery_mod._signal_contexts
+
+    def test_postrun_swallows_exit_failure(self):
+        """A failure exiting the context is swallowed; the entry is still cleared."""
+
+        class BoomExit:
+            def __exit__(self, *exc):
+                raise RuntimeError("connection lost")
+
+        celery_mod._signal_contexts["x"] = [BoomExit()]
+        celery_mod._task_postrun(task_id="x")  # must not raise
+        assert "x" not in celery_mod._signal_contexts
+
+
+class TestInstallUninstall:
+    """install() wires the publish signal; uninstall() removes it."""
+
+    def test_install_connects_and_uninstall_disconnects(self):
+        uninstall()  # ensure a clean baseline
+        set_current_tenant_id(7)
+
+        before: dict[str, object] = {}
+        before_task_publish.send(sender="rls-test", headers=before)
+        assert before == {}  # not connected yet
+
+        install()
+        try:
+            during: dict[str, object] = {}
+            before_task_publish.send(sender="rls-test", headers=during)
+            assert during == {_TENANT_HEADER: 7, _ADMIN_HEADER: False}
+        finally:
+            uninstall()
+
+        after: dict[str, object] = {}
+        before_task_publish.send(sender="rls-test", headers=after)
+        assert after == {}  # disconnected again
+
+    def test_install_is_idempotent(self):
+        install()
+        install()
+        try:
+            set_current_tenant_id(7)
+            headers: dict[str, object] = {}
+            before_task_publish.send(sender="rls-test", headers=headers)
+            assert headers == {_TENANT_HEADER: 7, _ADMIN_HEADER: False}
+        finally:
+            uninstall()
+
+    def test_uninstall_is_safe_without_install(self):
+        uninstall()
+        uninstall()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end isolation (live RLS enforcement)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.django_db
+class TestTaskIsolation:
+    """An @rls_task only sees its tenant's rows once RLS is enforced."""
+
+    def test_tenant_task_sees_only_its_rows(self, enforce_rls, sample_orders, tenant_a):
+        result = fetch_products.apply_async(headers={_TENANT_HEADER: tenant_a.pk}).get()
+        assert result == ["Widget A1", "Widget A2"]
+
+    def test_admin_task_sees_all_rows(self, enforce_rls, sample_orders):
+        result = fetch_products.apply_async(
+            headers={_TENANT_HEADER: None, _ADMIN_HEADER: True}
+        ).get()
+        assert result == ["Gadget B1", "Widget A1", "Widget A2"]

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,18 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "amqp"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "vine" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/fc/ec94a357dfc6683d8c86f8b4cfa5416a4c36b28052ec8260c77aca96a443/amqp-5.3.1.tar.gz", hash = "sha256:cddc00c725449522023bad949f70fff7b48f0b1ade74d170a6f10ab044739432", size = 129013, upload-time = "2024-11-12T19:55:44.051Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/99/fc813cd978842c26c82534010ea849eee9ab3a13ea2b74e95cb9c99e747b/amqp-5.3.1-py3-none-any.whl", hash = "sha256:43b3319e1b4e7d1251833a93d672b4af1e40f3d632d479b98661a95f117880a2", size = 50944, upload-time = "2024-11-12T19:55:41.782Z" },
+]
+
+[[package]]
 name = "asgiref"
 version = "3.11.1"
 source = { registry = "https://pypi.org/simple" }
@@ -76,6 +88,35 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/36/da/87912ddec6e06feffbaa3d7aa18fc6352bee2e8f1fee185d7d1690f8f4e8/backrefs-7.0-py312-none-any.whl", hash = "sha256:ca42ce6a49ace3d75684dfa9937f3373902a63284ecb385ce36d15e5dcb41c12", size = 398537, upload-time = "2026-04-28T16:27:58.913Z" },
     { url = "https://files.pythonhosted.org/packages/00/bb/90ba423612b6aa0adccc6b1874bcd4a9b44b660c0c16f346611e00f64ac3/backrefs-7.0-py313-none-any.whl", hash = "sha256:f2c52955d631b9e1ac4cd56209f0a3a946d592b98e7790e77699339ae01c102a", size = 400491, upload-time = "2026-04-28T16:28:00.928Z" },
     { url = "https://files.pythonhosted.org/packages/3e/5c/fb93d3092640a24dfb7bd7727a24016d7c01774ca013e60efd3f683c8002/backrefs-7.0-py314-none-any.whl", hash = "sha256:a6448b28180e3ca01134c9cf09dcebafad8531072e09903c5451748a05f24bc9", size = 412349, upload-time = "2026-04-28T16:28:02.412Z" },
+]
+
+[[package]]
+name = "billiard"
+version = "4.2.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/23/b12ac0bcdfb7360d664f40a00b1bda139cbbbced012c34e375506dbd0143/billiard-4.2.4.tar.gz", hash = "sha256:55f542c371209e03cd5862299b74e52e4fbcba8250ba611ad94276b369b6a85f", size = 156537, upload-time = "2025-11-30T13:28:48.52Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/87/8bab77b323f16d67be364031220069f79159117dd5e43eeb4be2fef1ac9b/billiard-4.2.4-py3-none-any.whl", hash = "sha256:525b42bdec68d2b983347ac312f892db930858495db601b5836ac24e6477cde5", size = 87070, upload-time = "2025-11-30T13:28:47.016Z" },
+]
+
+[[package]]
+name = "celery"
+version = "5.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "billiard" },
+    { name = "click" },
+    { name = "click-didyoumean" },
+    { name = "click-plugins" },
+    { name = "click-repl" },
+    { name = "kombu" },
+    { name = "python-dateutil" },
+    { name = "tzlocal" },
+    { name = "vine" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e8/b4/a1233943ab5c8ea05fb877a88a0a0622bf47444b99e4991a8045ac37ea1d/celery-5.6.3.tar.gz", hash = "sha256:177006bd2054b882e9f01be59abd8529e88879ef50d7918a7050c5a9f4e12912", size = 1742243, upload-time = "2026-03-26T12:14:51.76Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/c9/6eccdda96e098f7ae843162db2d3c149c6931a24fda69fe4ab84d0027eb5/celery-5.6.3-py3-none-any.whl", hash = "sha256:0808f42f80909c4d5833202360ffafb2a4f83f4d8e23e1285d926610e9a7afa6", size = 451235, upload-time = "2026-03-26T12:14:49.491Z" },
 ]
 
 [[package]]
@@ -195,6 +236,43 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
+]
+
+[[package]]
+name = "click-didyoumean"
+version = "0.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/30/ce/217289b77c590ea1e7c24242d9ddd6e249e52c795ff10fac2c50062c48cb/click_didyoumean-0.3.1.tar.gz", hash = "sha256:4f82fdff0dbe64ef8ab2279bd6aa3f6a99c3b28c05aa09cbfc07c9d7fbb5a463", size = 3089, upload-time = "2024-03-24T08:22:07.499Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/5b/974430b5ffdb7a4f1941d13d83c64a0395114503cc357c6b9ae4ce5047ed/click_didyoumean-0.3.1-py3-none-any.whl", hash = "sha256:5c4bb6007cfea5f2fd6583a2fb6701a22a41eb98957e63d0fac41c10e7c3117c", size = 3631, upload-time = "2024-03-24T08:22:06.356Z" },
+]
+
+[[package]]
+name = "click-plugins"
+version = "1.1.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/a4/34847b59150da33690a36da3681d6bbc2ec14ee9a846bc30a6746e5984e4/click_plugins-1.1.1.2.tar.gz", hash = "sha256:d7af3984a99d243c131aa1a828331e7630f4a88a9741fd05c927b204bcf92261", size = 8343, upload-time = "2025-06-25T00:47:37.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/9a/2abecb28ae875e39c8cad711eb1186d8d14eab564705325e77e4e6ab9ae5/click_plugins-1.1.1.2-py2.py3-none-any.whl", hash = "sha256:008d65743833ffc1f5417bf0e78e8d2c23aab04d9745ba817bd3e71b0feb6aa6", size = 11051, upload-time = "2025-06-25T00:47:36.731Z" },
+]
+
+[[package]]
+name = "click-repl"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "prompt-toolkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cb/a2/57f4ac79838cfae6912f997b4d1a64a858fb0c86d7fcaae6f7b58d267fca/click-repl-0.3.0.tar.gz", hash = "sha256:17849c23dba3d667247dc4defe1757fff98694e90fe37474f3feebb69ced26a9", size = 10449, upload-time = "2023-06-15T12:43:51.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/40/9d857001228658f0d59e97ebd4c346fe73e138c6de1bce61dc568a57c7f8/click_repl-0.3.0-py3-none-any.whl", hash = "sha256:fb7e06deb8da8de86180a33a9da97ac316751c094c6899382da7feeeeb51b812", size = 10289, upload-time = "2023-06-15T12:43:48.626Z" },
 ]
 
 [[package]]
@@ -348,6 +426,11 @@ dependencies = [
     { name = "django", version = "6.0.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 
+[package.optional-dependencies]
+celery = [
+    { name = "celery" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "django-stubs", extra = ["compatible-mypy"] },
@@ -357,11 +440,13 @@ dev = [
     { name = "ruff" },
 ]
 docs = [
+    { name = "celery" },
     { name = "mkdocs" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
 ]
 test = [
+    { name = "celery" },
     { name = "coverage", extra = ["toml"] },
     { name = "psycopg2-binary" },
     { name = "pytest" },
@@ -370,7 +455,11 @@ test = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "django", specifier = ">=4.2" }]
+requires-dist = [
+    { name = "celery", marker = "extra == 'celery'", specifier = ">=5.3" },
+    { name = "django", specifier = ">=4.2" },
+]
+provides-extras = ["celery"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -381,11 +470,13 @@ dev = [
     { name = "ruff", specifier = ">=0.8" },
 ]
 docs = [
+    { name = "celery", specifier = ">=5.3" },
     { name = "mkdocs", specifier = ">=1.6" },
     { name = "mkdocs-material", specifier = ">=9.5" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.27" },
 ]
 test = [
+    { name = "celery", specifier = ">=5.3" },
     { name = "coverage", extras = ["toml"], specifier = ">=7.0" },
     { name = "psycopg2-binary", specifier = ">=2.9" },
     { name = "pytest", specifier = ">=8.0" },
@@ -495,6 +586,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "kombu"
+version = "5.6.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "amqp" },
+    { name = "packaging" },
+    { name = "tzdata" },
+    { name = "vine" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b6/a5/607e533ed6c83ae1a696969b8e1c137dfebd5759a2e9682e26ff1b97740b/kombu-5.6.2.tar.gz", hash = "sha256:8060497058066c6f5aed7c26d7cd0d3b574990b09de842a8c5aaed0b92cc5a55", size = 472594, upload-time = "2025-12-29T20:30:07.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/0f/834427d8c03ff1d7e867d3db3d176470c64871753252b21b4f4897d1fa45/kombu-5.6.2-py3-none-any.whl", hash = "sha256:efcfc559da324d41d61ca311b0c64965ea35b4c55cc04ee36e55386145dace93", size = 214219, upload-time = "2025-12-29T20:30:05.74Z" },
 ]
 
 [[package]]
@@ -912,6 +1018,18 @@ wheels = [
 ]
 
 [[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
 name = "psycopg2-binary"
 version = "2.9.12"
 source = { registry = "https://pypi.org/simple" }
@@ -1259,12 +1377,33 @@ wheels = [
 ]
 
 [[package]]
+name = "tzlocal"
+version = "5.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/55/15e2340963d2bfedcc6042da3911438fd336f8ae96b65bdbe3a29766da0c/tzlocal-5.4.3.tar.gz", hash = "sha256:3a8c9bc18cf47e1dcde252ea0e6a72a6cde320a400b6ac6db1f1f8cccd553c00", size = 30873, upload-time = "2026-06-17T04:17:41.764Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/28/fc144409c71569e928585f8f3c629d80d1ca3ef40175e9222f01588f98c9/tzlocal-5.4.3-py3-none-any.whl", hash = "sha256:24ce97bb58e2a973f7640ec2553ab4e6f6d5a0d0d1aa9dc43bca21d89e1feb82", size = 18039, upload-time = "2026-06-17T04:17:40.027Z" },
+]
+
+[[package]]
 name = "urllib3"
 version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "vine"
+version = "5.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/e4/d07b5f29d283596b9727dd5275ccbceb63c44a1a82aa9e4bfd20426762ac/vine-5.1.0.tar.gz", hash = "sha256:8b62e981d35c41049211cf62a0a1242d8c1ee9bd15bb196ce38aefd6799e61e0", size = 48980, upload-time = "2023-11-05T08:46:53.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/ff/7c0c86c43b3cbb927e0ccc0255cb4057ceba4799cd44ae95174ce8e8b5b2/vine-5.1.0-py3-none-any.whl", hash = "sha256:40fdf3c48b2cfe1c38a49e9ae2da6fda88e4794c810050a728bd7413811fb1dc", size = 9636, upload-time = "2023-11-05T08:46:51.205Z" },
 ]
 
 [[package]]
@@ -1307,4 +1446,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
     { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
     { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/b4/51fe890511f0f242d07cb1ebe6a5b6db417262b9d2568b460347c57d95cc/wcwidth-0.8.1.tar.gz", hash = "sha256:faf5b4a5366a72dc49cad48cdf21f52bdf63bdda995178e483ba247ff79089b9", size = 1466072, upload-time = "2026-06-08T05:57:23.146Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/6e/95b0e537de1f4d4301f76f944642c6da50d1511cc7b3d64dc418a66c7509/wcwidth-0.8.1-py3-none-any.whl", hash = "sha256:f453740b1e4a4f3291faa37944c555d71056c4da08d59809b307ef4feba695c8", size = 323092, upload-time = "2026-06-08T05:57:21.413Z" },
 ]


### PR DESCRIPTION
## Related Issue

Closes #32

## Summary

Native Celery integration behind a new optional `celery` extra so background
tasks carry the RLS context automatically — no more threading `tenant_id`
through every task by hand:

- **`@rls_task`** — a `shared_task` drop-in that captures the active
  tenant/admin context into the task's message headers on enqueue and restores
  it around the whole body on the worker (unwinds on success *and* on exception).
- **`RLSTask`** — the base class doing the work; use `shared_task(base=RLSTask)`
  for a custom base. `rls_require_context = True` fails fast (with the #34 hint)
  instead of running unscoped.
- **`install()` / `uninstall()`** — an opt-in, signal-based escape hatch for
  tasks that cannot be re-based onto `RLSTask`.

Context propagates through chains, groups, and chords. Celery stays optional and
out of the top-level namespace; importing the module without it raises a clear
`ImportError`.

## Deep-review hardening (folded into the commit)

This branch went through a super-deep review (security, Python-quality, and
test-quality passes). Findings addressed:

- **`install()` escape-hatch robustness:** the signal handlers no longer let a
  GUC error escape into Celery's dispatcher — a prerun enter-failure now fails
  closed, and `uninstall()` best-effort exits any context still open from
  prerun so a stale context cannot leak into the next task (new `_safe_exit`
  helper; the thread-bound caveat is documented).
- **Capture-wiring regression guards:** added header-inspection tests proving
  `apply_async` / `apply` actually fold the live tenant/admin context into the
  message headers. The previous suite passed even with capture *deleted* —
  explicit-header tests bypass it and eager mode masks it via the outer
  `tenant_context`. These new tests fail if the capture wiring regresses.
- **Expanded coverage:** chord propagation (previously claimed but untested),
  `bind=True`, admin + `rls_require_context`, `tenant_id=0`, the missing-admin-key
  header path, and the signal failure paths. `contrib/celery.py` stays at 100%.
- **Docs:** made explicit that auto-restore covers the `default` DB alias only
  (non-default aliases must re-enter the context), plus a security-model note
  (task headers are trusted; admin context flows down a canvas).
- Small readability fix: `merged_headers` extracted in `apply_async` / `apply`.

Declined (with rationale): a Celery-specific error hint (the shared
`HINT_NO_CONTEXT` is intentionally reused per `errors.py`), an `_request_context`
admin guard (the suggested form would break admin propagation), and moving
`AbstractContextManager` to a runtime import (the repo's ruff `TCH` rule mandates
the `TYPE_CHECKING` placement).

## Testing

- `ruff check .` / `ruff format --check .` — clean
- `mypy` — clean in **both** the no-celery lint env and the celery-present test env
- `uv lock --check` — clean
- `mkdocs build --strict` — exit 0
- `pytest` — **624 passed @ 93%** (`POSTGRES_PORT=5433`); `contrib/celery.py` at 100%
